### PR TITLE
Refine leito reports and reservation flows

### DIFF
--- a/src/components/modals/ConfirmarInternacaoExternaModal.jsx
+++ b/src/components/modals/ConfirmarInternacaoExternaModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -44,6 +44,7 @@ const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) =>
   const [alertaConfirmacaoAberto, setAlertaConfirmacaoAberto] = useState(false);
   const [formAberto, setFormAberto] = useState(false);
   const [processando, setProcessando] = useState(false);
+  const formAbertoRef = useRef(false);
 
   const [dadosInternacao, setDadosInternacao] = useState({
     especialidade: '',
@@ -123,6 +124,10 @@ const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) =>
       return proximo;
     });
   };
+
+  useEffect(() => {
+    formAbertoRef.current = formAberto;
+  }, [formAberto]);
 
   const handleConfirmarAlerta = () => {
     setAlertaConfirmacaoAberto(false);
@@ -239,7 +244,7 @@ const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) =>
         open={alertaConfirmacaoAberto}
         onOpenChange={(open) => {
           setAlertaConfirmacaoAberto(open);
-          if (!open && !formAberto) {
+          if (!open && !formAbertoRef.current) {
             handleFecharTudo();
           }
         }}

--- a/src/components/modals/InformacoesReservaModal.jsx
+++ b/src/components/modals/InformacoesReservaModal.jsx
@@ -22,9 +22,11 @@ import {
   arrayUnion
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const InformacoesReservaModal = ({ isOpen, onClose, reserva }) => {
   const { toast } = useToast();
+  const { currentUser } = useAuth();
   const [novaObservacao, setNovaObservacao] = useState('');
   const [salvandoObservacao, setSalvandoObservacao] = useState(false);
 
@@ -53,7 +55,7 @@ const InformacoesReservaModal = ({ isOpen, onClose, reserva }) => {
       const observacao = {
         texto: novaObservacao.trim(),
         data: new Date(),
-        usuarioNome: 'Usuário do Sistema' // TODO: Pegar do contexto de auth
+        usuarioNome: currentUser?.nomeCompleto || 'Usuário Desconhecido'
       };
 
       await updateDoc(

--- a/src/components/modals/ReservasLeitosModal.jsx
+++ b/src/components/modals/ReservasLeitosModal.jsx
@@ -382,10 +382,11 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
                     ) : (
                       <div className="space-y-3">
                         {reservasProcessadas.sisreg.map(reserva => (
-                          <ReservaCard 
-                            key={reserva.id} 
-                            reserva={reserva} 
+                          <ReservaCard
+                            key={reserva.id}
+                            reserva={reserva}
                             onOpenSubModal={openSubModal}
+                            leitos={dados.leitos}
                           />
                         ))}
                       </div>
@@ -406,10 +407,11 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
                     ) : (
                       <div className="space-y-3">
                         {reservasProcessadas.oncologia.map(reserva => (
-                          <ReservaCard 
-                            key={reserva.id} 
-                            reserva={reserva} 
+                          <ReservaCard
+                            key={reserva.id}
+                            reserva={reserva}
                             onOpenSubModal={openSubModal}
+                            leitos={dados.leitos}
                           />
                         ))}
                       </div>
@@ -707,7 +709,7 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
 };
 
 // Componente para cada card de reserva
-const ReservaCard = ({ reserva, onOpenSubModal }) => {
+const ReservaCard = ({ reserva, onOpenSubModal, leitos }) => {
   const { toast } = useToast();
   const [confirmacaoCancelarOpen, setConfirmacaoCancelarOpen] = useState(false);
 
@@ -735,6 +737,12 @@ const ReservaCard = ({ reserva, onOpenSubModal }) => {
     ['HRHDS', 'REGIONAL'].includes(instituicaoUpper) &&
     dataSolicitacao &&
     differenceInHours(new Date(), dataSolicitacao) > 72;
+
+  const leitoReservado = useMemo(() => {
+    if (!reserva.leitoReservadoId) return null;
+    const listaLeitos = Array.isArray(leitos) ? leitos : [];
+    return listaLeitos.find(leitoAtual => leitoAtual.id === reserva.leitoReservadoId) || null;
+  }, [leitos, reserva.leitoReservadoId]);
 
   const alertas = [];
   if (atrasoOncologia) {
@@ -819,7 +827,9 @@ const ReservaCard = ({ reserva, onOpenSubModal }) => {
                 {reserva.status || 'Status desconhecido'}
               </Badge>
               {reserva.leitoReservadoId && (
-                <Badge variant="outline">Leito Reservado</Badge>
+                <Badge variant="outline">
+                  Leito: {leitoReservado?.codigoLeito || '...'}
+                </Badge>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- densified the vacant bed report, adding cohort compatibility metadata and presenting the data in a compact tabular layout with improved copy-to-clipboard output
- captured the authenticated reviewer when registering reservation observations and stabilized the external admission confirmation flow so the complementary form opens after the alert
- surfaced the reserved bed code inside reservation cards by sharing the leitos dataset with each card

## Testing
- npm run lint *(fails: missing @eslint/js in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68caa7f7a7788322809ed7b554377c68