### PR TITLE
Add contamination risk alerts and show locations on isolation cards

### DIFF
--- a/src/components/RemanejamentosPendentesPanel.jsx
+++ b/src/components/RemanejamentosPendentesPanel.jsx
@@ -172,6 +172,7 @@ const RemanejamentosPendentesPanel = () => {
   const PacienteRemanejamentoCard = ({ paciente }) => {
     const localizacao = obterLocalizacaoAtual(paciente);
     const tempoSolicitacao = calcularTempoSolicitacao(paciente.pedidoRemanejamento.timestamp);
+    const isCancelavel = paciente.pedidoRemanejamento?.tipo !== 'Risco de Contaminação Cruzada';
 
     return (
       <Card className="p-4 hover:shadow-md transition-shadow border border-muted">
@@ -213,15 +214,17 @@ const RemanejamentosPendentesPanel = () => {
 
           {/* Ações */}
           <div className="flex justify-end gap-2 pt-2 border-t">
-            <Button 
-              variant="destructive" 
-              size="sm"
-              onClick={() => setModalCancelar({ isOpen: true, paciente })}
-            >
-              Cancelar
-            </Button>
-            <Button 
-              variant="default" 
+            {isCancelavel && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setModalCancelar({ isOpen: true, paciente })}
+              >
+                Cancelar
+              </Button>
+            )}
+            <Button
+              variant="default"
               size="sm"
               onClick={() => handleRemanejarPaciente(paciente)}
             >


### PR DESCRIPTION
## Summary
- surface the current sector and bed on suspected and confirmed isolation cards by enriching patient data with bed and sector lookups
- add real-time detection for cross-contamination risks in emergency/enfermaria areas, auto-managing remanejamento requests and exposing them in a dedicated alert accordion
- hide the manual cancel action for auto-generated cross-contamination remanejamento requests

## Testing
- npm run lint *(fails: existing lint errors in shared UI TypeScript files)*

------
https://chatgpt.com/codex/tasks/task_e_68caae5af25c8322a400de957c032d9d