### PR TITLE
Fix remanejamento info and restore UTI/transfer workflows

### DIFF
--- a/src/components/RemanejamentosPendentesPanel.jsx
+++ b/src/components/RemanejamentosPendentesPanel.jsx
@@ -205,7 +205,7 @@ const RemanejamentosPendentesPanel = () => {
           </div>
 
           {/* Justificativa */}
-          {paciente.pedidoRemanejamento.descricao && (
+          {paciente.pedidoRemanejamento?.descricao && (
             <div className="text-xs text-muted-foreground">
               <span className="font-medium">Justificativa: </span>
               <span className="italic">{paciente.pedidoRemanejamento.descricao}</span>

--- a/src/components/modals/ConfirmarRegulacaoModal.jsx
+++ b/src/components/modals/ConfirmarRegulacaoModal.jsx
@@ -53,15 +53,17 @@ const ConfirmarRegulacaoModal = ({
     // Personalizar mensagem baseado no modo
     let titulo = '*LEITO REGULADO*';
     let justificativaTexto = '';
-    
+
     if (modo === 'remanejamento') {
       titulo = '*REMANEJAMENTO SOLICITADO*';
       if (paciente.pedidoRemanejamento) {
-        justificativaTexto = `\n*Justificativa:* _${paciente.pedidoRemanejamento.tipo}`;
-        if (paciente.pedidoRemanejamento.descricao) {
-          justificativaTexto += ` - ${paciente.pedidoRemanejamento.descricao}`;
+        const tipoJustificativa = paciente.pedidoRemanejamento.tipo || '';
+        const descricaoJustificativa = paciente.pedidoRemanejamento.descricao;
+        const justificativa = `${tipoJustificativa}${descricaoJustificativa ? `: ${descricaoJustificativa}` : ''}`.trim();
+
+        if (justificativa) {
+          justificativaTexto = `\n*Justificativa:* _${justificativa}_`;
         }
-        justificativaTexto += '_';
       }
     }
 

--- a/src/components/modals/TransferenciaExternaModal.jsx
+++ b/src/components/modals/TransferenciaExternaModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -9,6 +9,22 @@ const TransferenciaExternaModal = ({ isOpen, onClose, onSave, paciente }) => {
   const [motivo, setMotivo] = useState('');
   const [outroMotivo, setOutroMotivo] = useState('');
   const [destino, setDestino] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const pedido = paciente?.pedidoTransferenciaExterna;
+
+    if (pedido) {
+      setMotivo(pedido.motivo || '');
+      setOutroMotivo(pedido.outroMotivo || '');
+      setDestino(pedido.destino && pedido.destino !== 'Não informado' ? pedido.destino : '');
+    } else {
+      setMotivo('');
+      setOutroMotivo('');
+      setDestino('');
+    }
+  }, [isOpen, paciente]);
 
   const motivosTransferencia = [
     'UTI',


### PR DESCRIPTION
## Summary
- pull remanejamento justification from `pedidoRemanejamento.descricao` for cards and WhatsApp preview
- enable cancelamento de pedido UTI with confirmação, logging and toast feedback
- allow abertura/edição de pedidos de transferência externa a partir da fila e do painel dedicado, com formulário pré-preenchido

## Testing
- npm run lint *(fails: missing @eslint/js dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab8b46fe483229665d39eeb90fdbf