### PR TITLE
Implement global filters and isolation fixes

### DIFF
--- a/src/components/FilaEsperaUTIPanel.jsx
+++ b/src/components/FilaEsperaUTIPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -46,7 +46,20 @@ const formatDurationShort = (start) => {
   return `${dur.minutes || 0}m`;
 };
 
-const FilaEsperaUTIPanel = () => {
+const normalizarTexto = (texto) =>
+  String(texto || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+
+const normalizarSexo = (valor) => {
+  const sexoNormalizado = normalizarTexto(valor);
+  if (sexoNormalizado.startsWith('m')) return 'M';
+  if (sexoNormalizado.startsWith('f')) return 'F';
+  return '';
+};
+
+const FilaEsperaUTIPanel = ({ filtros, sortConfig }) => {
   const [pacientes, setPacientes] = useState([]);
   const [setores, setSetores] = useState([]);
   const [leitos, setLeitos] = useState([]);
@@ -98,21 +111,193 @@ const FilaEsperaUTIPanel = () => {
     return found?.codigoLeito || '—';
   };
 
-  // Filtrar pacientes que têm pedido UTI, não estão em regulação ativa e não estão em UTI
-  const pedidos = pacientes.filter((p) => {
-    if (!p?.pedidoUTI) return false;
-    if (p?.regulacaoAtiva) return false;
-    if (p?.pedidoTransferenciaExterna) return false;
-    
-    // Verificar se o paciente já está em UTI
-    const leitoAtual = leitos.find(l => l.id === p.leitoId);
-    if (leitoAtual) {
-      const setorAtual = setores.find(s => s.id === leitoAtual.setorId);
-      if (setorAtual?.tipoSetor === 'UTI') return false;
+  const calcularIdade = (dataNascimento) => {
+    if (!dataNascimento) return 0;
+
+    let dataObj;
+
+    if (typeof dataNascimento === 'string' && dataNascimento.includes('/')) {
+      const [dia, mes, ano] = dataNascimento.split('/');
+      dataObj = new Date(parseInt(ano, 10), parseInt(mes, 10) - 1, parseInt(dia, 10));
+    } else if (dataNascimento && typeof dataNascimento.toDate === 'function') {
+      dataObj = dataNascimento.toDate();
+    } else {
+      dataObj = new Date(dataNascimento);
     }
-    
-    return true;
-  });
+
+    if (isNaN(dataObj?.getTime?.())) {
+      return 0;
+    }
+
+    const hoje = new Date();
+    let idade = hoje.getFullYear() - dataObj.getFullYear();
+    const m = hoje.getMonth() - dataObj.getMonth();
+
+    if (m < 0 || (m === 0 && hoje.getDate() < dataObj.getDate())) {
+      idade--;
+    }
+
+    return idade;
+  };
+
+  const parseData = (valor) => {
+    if (!valor) return null;
+
+    let dataObj;
+
+    if (typeof valor === 'string' && valor.includes('/')) {
+      const partes = valor.split(' ');
+      const [dia, mes, ano] = partes[0].split('/');
+
+      if (partes.length > 1 && partes[1].includes(':')) {
+        const [hora, minuto] = partes[1].split(':');
+        dataObj = new Date(
+          parseInt(ano, 10),
+          parseInt(mes, 10) - 1,
+          parseInt(dia, 10),
+          parseInt(hora, 10),
+          parseInt(minuto, 10)
+        );
+      } else {
+        dataObj = new Date(parseInt(ano, 10), parseInt(mes, 10) - 1, parseInt(dia, 10));
+      }
+    } else if (valor && typeof valor.toDate === 'function') {
+      dataObj = valor.toDate();
+    } else {
+      dataObj = new Date(valor);
+    }
+
+    if (isNaN(dataObj?.getTime?.())) {
+      return null;
+    }
+
+    return dataObj;
+  };
+
+  const calcularTempoInternacaoHoras = (dataInternacao) => {
+    const dataObj = parseData(dataInternacao);
+    if (!dataObj) return null;
+    const diffMs = Date.now() - dataObj.getTime();
+    return diffMs / (1000 * 60 * 60);
+  };
+
+  const pedidos = useMemo(() => {
+    const base = pacientes.filter((p) => {
+      if (!p?.pedidoUTI) return false;
+      if (p?.regulacaoAtiva) return false;
+      if (p?.pedidoTransferenciaExterna) return false;
+
+      const leitoAtual = leitos.find(l => l.id === p.leitoId);
+      if (leitoAtual) {
+        const setorAtual = setores.find(s => s.id === leitoAtual.setorId);
+        if (setorAtual?.tipoSetor === 'UTI') return false;
+      }
+
+      return true;
+    });
+
+    const {
+      searchTerm = '',
+      especialidade = 'todos',
+      sexo = 'todos',
+      idadeMin = '',
+      idadeMax = '',
+      tempoInternacaoMin = '',
+      tempoInternacaoMax = '',
+      unidadeTempo = 'dias'
+    } = filtros || {};
+
+    const termoBuscaNormalizado = normalizarTexto(searchTerm);
+    const especialidadeFiltro = normalizarTexto(especialidade);
+    const sexoFiltro = sexo || 'todos';
+    const idadeMinNumero = idadeMin !== '' ? Number(idadeMin) : null;
+    const idadeMaxNumero = idadeMax !== '' ? Number(idadeMax) : null;
+    const tempoMinNumero = tempoInternacaoMin !== '' ? Number(tempoInternacaoMin) : null;
+    const tempoMaxNumero = tempoInternacaoMax !== '' ? Number(tempoInternacaoMax) : null;
+
+    const filtrados = base.filter((paciente) => {
+      if (termoBuscaNormalizado) {
+        const nomeNormalizado = normalizarTexto(paciente.nomePaciente);
+        if (!nomeNormalizado.includes(termoBuscaNormalizado)) {
+          return false;
+        }
+      }
+
+      if (especialidadeFiltro && especialidadeFiltro !== 'todos') {
+        const especialidadePaciente = normalizarTexto(paciente.especialidade);
+        if (!especialidadePaciente.includes(especialidadeFiltro)) {
+          return false;
+        }
+      }
+
+      if (sexoFiltro && sexoFiltro !== 'todos') {
+        if (normalizarSexo(paciente.sexo) !== sexoFiltro) {
+          return false;
+        }
+      }
+
+      const idade = calcularIdade(paciente.dataNascimento);
+      if (idadeMinNumero !== null && idade < idadeMinNumero) {
+        return false;
+      }
+      if (idadeMaxNumero !== null && idade > idadeMaxNumero) {
+        return false;
+      }
+
+      const tempoHoras = calcularTempoInternacaoHoras(paciente.dataInternacao);
+      const tempoMinHoras =
+        tempoMinNumero !== null
+          ? unidadeTempo === 'dias'
+            ? tempoMinNumero * 24
+            : tempoMinNumero
+          : null;
+      const tempoMaxHoras =
+        tempoMaxNumero !== null
+          ? unidadeTempo === 'dias'
+            ? tempoMaxNumero * 24
+            : tempoMaxNumero
+          : null;
+
+      if (tempoMinHoras !== null) {
+        if (tempoHoras === null || tempoHoras < tempoMinHoras) {
+          return false;
+        }
+      }
+
+      if (tempoMaxHoras !== null) {
+        if (tempoHoras === null || tempoHoras > tempoMaxHoras) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    const direction = sortConfig?.direction === 'desc' ? -1 : 1;
+    const key = sortConfig?.key || 'nome';
+
+    return filtrados.sort((a, b) => {
+      if (key === 'idade') {
+        const idadeA = calcularIdade(a.dataNascimento);
+        const idadeB = calcularIdade(b.dataNascimento);
+        return direction * (idadeA - idadeB);
+      }
+
+      if (key === 'tempoInternacao') {
+        const tempoA = calcularTempoInternacaoHoras(a.dataInternacao);
+        const tempoB = calcularTempoInternacaoHoras(b.dataInternacao);
+        const valorA =
+          tempoA ?? (direction === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY);
+        const valorB =
+          tempoB ?? (direction === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY);
+        return direction * (valorA - valorB);
+      }
+
+      const nomeA = normalizarTexto(a.nomePaciente);
+      const nomeB = normalizarTexto(b.nomePaciente);
+      return direction * nomeA.localeCompare(nomeB);
+    });
+  }, [pacientes, leitos, setores, filtros, sortConfig]);
 
   const handleIniciarRegulacao = (paciente) => {
     setPacienteSelecionado(paciente);

--- a/src/components/FiltrosRegulacao.jsx
+++ b/src/components/FiltrosRegulacao.jsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Filter, RotateCcw, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+
+const defaultFilters = {
+  searchTerm: '',
+  especialidade: 'todos',
+  sexo: 'todos',
+  idadeMin: '',
+  idadeMax: '',
+  tempoInternacaoMin: '',
+  tempoInternacaoMax: '',
+  unidadeTempo: 'dias'
+};
+
+const defaultSort = { key: 'nome', direction: 'asc' };
+
+const especialidadeOptions = [
+  { value: 'todos', label: 'Todas' },
+  { value: 'clinica', label: 'Clínica Médica' },
+  { value: 'cirurgia', label: 'Cirurgia' },
+  { value: 'cardiologia', label: 'Cardiologia' },
+  { value: 'neurologia', label: 'Neurologia' },
+  { value: 'ortopedia', label: 'Ortopedia' },
+  { value: 'pediatria', label: 'Pediatria' }
+];
+
+const sexoOptions = [
+  { value: 'todos', label: 'Todos' },
+  { value: 'M', label: 'Masculino' },
+  { value: 'F', label: 'Feminino' }
+];
+
+const sortOptions = [
+  { key: 'nome', label: 'Nome' },
+  { key: 'idade', label: 'Idade' },
+  { key: 'tempoInternacao', label: 'Tempo Internação' }
+];
+
+const FiltrosRegulacao = ({
+  filtros,
+  setFiltros,
+  sortConfig,
+  setSortConfig,
+  initialFilters = defaultFilters,
+  defaultSortConfig = defaultSort
+}) => {
+  const handleInputChange = (field) => (event) => {
+    const value = event.target.value;
+    setFiltros((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleSelectChange = (field) => (value) => {
+    setFiltros((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleClearFilters = () => {
+    setFiltros({ ...initialFilters });
+    setSortConfig({ ...defaultSortConfig });
+  };
+
+  const toggleSort = (key) => {
+    setSortConfig((prev) => {
+      if (prev.key === key) {
+        return {
+          key,
+          direction: prev.direction === 'asc' ? 'desc' : 'asc'
+        };
+      }
+      return { key, direction: 'asc' };
+    });
+  };
+
+  const getSortIcon = (key) => {
+    if (sortConfig.key !== key) {
+      return <ArrowUpDown className="h-4 w-4" />;
+    }
+    return sortConfig.direction === 'asc' ? (
+      <ArrowUp className="h-4 w-4" />
+    ) : (
+      <ArrowDown className="h-4 w-4" />
+    );
+  };
+
+  return (
+    <Card className="shadow-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Filter className="h-5 w-5 text-primary" />
+          Filtros e Pesquisa
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="md:col-span-2">
+            <Label className="text-xs uppercase text-muted-foreground">Pesquisar por nome</Label>
+            <Input
+              placeholder="Digite o nome do paciente"
+              value={filtros.searchTerm}
+              onChange={handleInputChange('searchTerm')}
+            />
+          </div>
+          <div>
+            <Label className="text-xs uppercase text-muted-foreground">Especialidade</Label>
+            <Select value={filtros.especialidade} onValueChange={handleSelectChange('especialidade')}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todas" />
+              </SelectTrigger>
+              <SelectContent>
+                {especialidadeOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div>
+            <Label className="text-xs uppercase text-muted-foreground">Sexo</Label>
+            <Select value={filtros.sexo} onValueChange={handleSelectChange('sexo')}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todos" />
+              </SelectTrigger>
+              <SelectContent>
+                {sexoOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label className="text-xs uppercase text-muted-foreground">Idade mínima</Label>
+            <Input
+              type="number"
+              min="0"
+              value={filtros.idadeMin}
+              onChange={handleInputChange('idadeMin')}
+              placeholder="Min"
+            />
+          </div>
+          <div>
+            <Label className="text-xs uppercase text-muted-foreground">Idade máxima</Label>
+            <Input
+              type="number"
+              min="0"
+              value={filtros.idadeMax}
+              onChange={handleInputChange('idadeMax')}
+              placeholder="Max"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="col-span-1">
+              <Label className="text-xs uppercase text-muted-foreground">Tempo mín.</Label>
+              <Input
+                type="number"
+                min="0"
+                value={filtros.tempoInternacaoMin}
+                onChange={handleInputChange('tempoInternacaoMin')}
+                placeholder="0"
+              />
+            </div>
+            <div className="col-span-1">
+              <Label className="text-xs uppercase text-muted-foreground">Tempo máx.</Label>
+              <Input
+                type="number"
+                min="0"
+                value={filtros.tempoInternacaoMax}
+                onChange={handleInputChange('tempoInternacaoMax')}
+                placeholder="0"
+              />
+            </div>
+            <div className="col-span-1">
+              <Label className="text-xs uppercase text-muted-foreground">Unidade</Label>
+              <Select value={filtros.unidadeTempo} onValueChange={handleSelectChange('unidadeTempo')}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Dias" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="dias">Dias</SelectItem>
+                  <SelectItem value="horas">Horas</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold uppercase text-muted-foreground">Ordenar por</span>
+            {sortOptions.map((option) => {
+              const isActive = sortConfig.key === option.key;
+              return (
+                <Button
+                  key={option.key}
+                  type="button"
+                  variant={isActive ? 'default' : 'outline'}
+                  size="sm"
+                  className="flex items-center gap-2"
+                  onClick={() => toggleSort(option.key)}
+                >
+                  {option.label}
+                  {getSortIcon(option.key)}
+                </Button>
+              );
+            })}
+          </div>
+
+          <Button
+            type="button"
+            variant="ghost"
+            className="gap-2 self-start"
+            onClick={handleClearFilters}
+          >
+            <RotateCcw className="h-4 w-4" />
+            Limpar filtros
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FiltrosRegulacao;

--- a/src/components/RegulacaoLeitosPage.jsx
+++ b/src/components/RegulacaoLeitosPage.jsx
@@ -1,16 +1,10 @@
 import React, { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { 
-  TrendingUp, 
-  Wrench, 
-  Filter, 
-  Users, 
-  Loader, 
-  BedDouble, 
-  Truck, 
-  Stethoscope, 
-  ArrowRightLeft,
+import {
+  TrendingUp,
+  Wrench,
+  Stethoscope,
   DatabaseIcon,
   BookUser,
   Sparkles,
@@ -22,8 +16,25 @@ import FilaEsperaUTIPanel from './FilaEsperaUTIPanel';
 import TransferenciaExternaPanel from './TransferenciaExternaPanel';
 import RegulacoesEmAndamentoPanel from './RegulacoesEmAndamentoPanel';
 import RemanejamentosPendentesPanel from './RemanejamentosPendentesPanel';
+import FiltrosRegulacao from './FiltrosRegulacao';
+
+const filtrosIniciais = {
+  searchTerm: '',
+  especialidade: 'todos',
+  sexo: 'todos',
+  idadeMin: '',
+  idadeMax: '',
+  tempoInternacaoMin: '',
+  tempoInternacaoMax: '',
+  unidadeTempo: 'dias'
+};
+
+const sortConfigInicial = { key: 'nome', direction: 'asc' };
+
 const RegulacaoLeitosPage = () => {
   const [showImportModal, setShowImportModal] = useState(false);
+  const [filtros, setFiltros] = useState(filtrosIniciais);
+  const [sortConfig, setSortConfig] = useState(sortConfigInicial);
 
   return (
     <div className="p-6 space-y-6">
@@ -54,33 +65,33 @@ const RegulacaoLeitosPage = () => {
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <Button 
-                variant="outline" 
-                className="flex items-center gap-2" 
+              <Button
+                variant="outline"
+                className="flex items-center gap-2"
                 onClick={() => setShowImportModal(true)}
               >
                 <DatabaseIcon className="h-4 w-4" />
                 Importar Pacientes MV
               </Button>
-              <Button 
-                variant="outline" 
-                className="flex items-center gap-2 opacity-60 cursor-not-allowed" 
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 opacity-60 cursor-not-allowed"
                 disabled
               >
                 <BookUser className="h-4 w-4" />
                 Passagem de Plantão
               </Button>
-              <Button 
-                variant="outline" 
-                className="flex items-center gap-2 opacity-60 cursor-not-allowed" 
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 opacity-60 cursor-not-allowed"
                 disabled
               >
                 <Sparkles className="h-4 w-4" />
                 Sugestões de Regulação
               </Button>
-              <Button 
-                variant="outline" 
-                className="flex items-center gap-2 opacity-60 cursor-not-allowed" 
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 opacity-60 cursor-not-allowed"
                 disabled
               >
                 <PieChart className="h-4 w-4" />
@@ -93,41 +104,33 @@ const RegulacaoLeitosPage = () => {
 
       {/* Seção 2: Filtros */}
       <section>
-        <Card className="shadow-card">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Filter className="h-5 w-5 text-primary" />
-              Filtros e Pesquisa
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-muted-foreground">
-              Opções de filtro para os painéis abaixo serão implementadas aqui.
-            </p>
-            <div className="mt-3 text-xs text-muted-foreground/70">
-              ▼ Esta área será expansível
-            </div>
-          </CardContent>
-        </Card>
+        <FiltrosRegulacao
+          filtros={filtros}
+          setFiltros={setFiltros}
+          sortConfig={sortConfig}
+          setSortConfig={setSortConfig}
+          initialFilters={filtrosIniciais}
+          defaultSortConfig={sortConfigInicial}
+        />
       </section>
 
       {/* Seção 3: Painel Principal de Regulação */}
       <section>
         <div className="space-y-6">
           {/* Painel de Pacientes Aguardando Regulação */}
-          <AguardandoRegulacaoPanel />
+          <AguardandoRegulacaoPanel filtros={filtros} sortConfig={sortConfig} />
 
           {/* Linha: Fila UTI + Transferência Externa */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <FilaEsperaUTIPanel />
-            <TransferenciaExternaPanel />
+            <FilaEsperaUTIPanel filtros={filtros} sortConfig={sortConfig} />
+            <TransferenciaExternaPanel filtros={filtros} sortConfig={sortConfig} />
           </div>
 
           {/* Painel de Remanejamentos Pendentes */}
-          <RemanejamentosPendentesPanel />
+          <RemanejamentosPendentesPanel filtros={filtros} sortConfig={sortConfig} />
 
           {/* Painel de Regulações em Andamento */}
-          <RegulacoesEmAndamentoPanel />
+          <RegulacoesEmAndamentoPanel filtros={filtros} sortConfig={sortConfig} />
 
           {/* Outros Cards em Grid - ÚLTIMO ITEM */}
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
@@ -150,9 +153,9 @@ const RegulacaoLeitosPage = () => {
       </section>
 
       {/* Modal de Importação */}
-      <ImportarPacientesMVModal 
-        isOpen={showImportModal} 
-        onClose={() => setShowImportModal(false)} 
+      <ImportarPacientesMVModal
+        isOpen={showImportModal}
+        onClose={() => setShowImportModal(false)}
       />
     </div>
   );

--- a/src/components/modals/ConfirmarRegulacaoModal.jsx
+++ b/src/components/modals/ConfirmarRegulacaoModal.jsx
@@ -43,9 +43,15 @@ const ConfirmarRegulacaoModal = ({
     // Obter nomes das infecções
     const nomesInfeccoes = (paciente.isolamentos || [])
       .map(iso => {
-        const infeccao = infeccoes.find(inf => inf.id === iso.infecaoId);
-        return infeccao ? infeccao.nomeInfeccao : 'Infecção não identificada';
+        const infeccaoId = iso.infeccaoId || iso.infecaoId;
+        if (!infeccaoId) return null;
+        const infeccao = infeccoes.find(inf => inf.id === infeccaoId);
+        if (infeccao) {
+          return infeccao.siglaInfeccao || infeccao.nomeInfeccao;
+        }
+        return `ID:${infeccaoId}`;
       })
+      .filter(Boolean)
       .join(', ');
 
     const dataHora = format(new Date(), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR });
@@ -58,7 +64,8 @@ const ConfirmarRegulacaoModal = ({
       titulo = '*REMANEJAMENTO SOLICITADO*';
       if (paciente.pedidoRemanejamento) {
         const tipoJustificativa = paciente.pedidoRemanejamento.tipo || '';
-        const descricaoJustificativa = paciente.pedidoRemanejamento.descricao;
+        const descricaoJustificativa =
+          paciente.pedidoRemanejamento.detalhe || paciente.pedidoRemanejamento.descricao;
         const justificativa = `${tipoJustificativa}${descricaoJustificativa ? `: ${descricaoJustificativa}` : ''}`.trim();
 
         if (justificativa) {


### PR DESCRIPTION
## Summary
- add a reusable filter panel and central state so regulation views share the same search, range and ordering controls
- apply the new filter/sort logic to all regulation patient panels while fixing remanejamento detail rendering
- adjust isolation messaging to prefer siglas and enrich automatic remanejamento descriptions for risk cases

## Testing
- npm run lint *(fails: existing eslint violations under src/components/ui and tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cac0d4a2188322a897a568f4a70e65