### PR TITLE
Add indicator tooltips and compact toolbox buttons

### DIFF
--- a/src/components/IndicadoresGeraisPanel.jsx
+++ b/src/components/IndicadoresGeraisPanel.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { 
   TrendingUp, 
   Users, 
@@ -243,24 +244,60 @@ const IndicadoresGeraisPanel = ({ setores, leitos, pacientes }) => {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center text-sm">
-                <span className="text-red-600 font-medium">Ocupados:</span>
-                <span>{indicadores.resumoStatus.ocupados.total}</span>
+            <TooltipProvider>
+              <div className="space-y-2">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-red-600 font-medium">Ocupados:</span>
+                      <span>{indicadores.resumoStatus.ocupados.total}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Soma de todos os leitos com status 'Ocupado', 'Regulado' ou que possuem uma
+                      reserva externa confirmada.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-green-600 font-medium">Vagos (Reguláveis):</span>
+                      <span>{indicadores.resumoStatus.vagosRegulaveis.total}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Soma de todos os leitos com status 'Vago' que não possuem nenhuma regulação ou
+                      reserva pendente.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-yellow-600 font-medium">Higienização:</span>
+                      <span>{indicadores.resumoStatus.higienizacao.total}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Soma de todos os leitos com status 'Higienização'.</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-gray-600 font-medium">Bloqueados:</span>
+                      <span>{indicadores.resumoStatus.bloqueados.total}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Soma de todos os leitos com status 'Bloqueado'.</p>
+                  </TooltipContent>
+                </Tooltip>
               </div>
-              <div className="flex justify-between items-center text-sm">
-                <span className="text-green-600 font-medium">Vagos (Reguláveis):</span>
-                <span>{indicadores.resumoStatus.vagosRegulaveis.total}</span>
-              </div>
-              <div className="flex justify-between items-center text-sm">
-                <span className="text-yellow-600 font-medium">Higienização:</span>
-                <span>{indicadores.resumoStatus.higienizacao.total}</span>
-              </div>
-              <div className="flex justify-between items-center text-sm">
-                <span className="text-gray-600 font-medium">Bloqueados:</span>
-                <span>{indicadores.resumoStatus.bloqueados.total}</span>
-              </div>
-            </div>
+            </TooltipProvider>
           </CardContent>
         </Card>
       </div>

--- a/src/components/MapaLeitosPage.jsx
+++ b/src/components/MapaLeitosPage.jsx
@@ -108,44 +108,49 @@ const MapaLeitosPage = () => {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-            <Button 
-              variant="outline" 
-              className="flex items-center gap-2" 
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2"
               onClick={() => setShowGerenciamentoModal(true)}
             >
               <Settings2 className="h-4 w-4" />
               Gerenciar leitos
             </Button>
-            
-            <Button 
-              variant="outline" 
+
+            <Button
+              variant="outline"
+              size="sm"
               className="flex items-center gap-2"
               onClick={() => setShowRelatorioIsolamentosModal(true)}
             >
               <Activity className="h-4 w-4" />
               Relatório de isolamentos
             </Button>
-            
-            <Button 
-              variant="outline" 
+
+            <Button
+              variant="outline"
+              size="sm"
               className="flex items-center gap-2"
               onClick={() => setShowRelatorioLeitosVagosModal(true)}
             >
               <Download className="h-4 w-4" />
               Relatório de leitos vagos
             </Button>
-            
-            <Button 
-              variant="outline" 
+
+            <Button
+              variant="outline"
+              size="sm"
               className="flex items-center gap-2"
             >
               <Activity className="h-4 w-4" />
               Boletim diário
             </Button>
 
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
+              size="sm"
               className="flex items-center gap-2"
               onClick={() => setShowReservasLeitosModal(true)}
             >


### PR DESCRIPTION
## Summary
- add descriptive tooltips to the quick summary indicators, explaining how each status total is calculated
- import the shared tooltip components needed for the new hover help text
- shrink the toolbox buttons and expand the large-screen grid so the actions fit on a single row

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3c6f89888322bbae370e69799090