### PR TITLE
Validate beds before updating during sync

### DIFF
--- a/src/components/ImportarPacientesMVModal.jsx
+++ b/src/components/ImportarPacientesMVModal.jsx
@@ -412,6 +412,7 @@ const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
       }
       return acc;
     }, {});
+    const leitosIdSet = new Set(Object.values(leitosMap).map(leito => leito.id));
 
     const errosLeitosMap = new Map();
     const registrarErroLeito = (nome, codigo) => {
@@ -510,7 +511,9 @@ const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
       processedData.altas.forEach(paciente => {
         const pacienteRef = doc(db, PATIENTS_COLLECTION_PATH, paciente.id);
         batch.delete(pacienteRef);
-        leitosParaAtualizar.add(paciente.leitoId);
+        if (paciente.leitoId && leitosIdSet.has(paciente.leitoId)) {
+          leitosParaAtualizar.add(paciente.leitoId);
+        }
       });
 
       // Executar movimentações
@@ -613,6 +616,9 @@ const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
 
       // Atualizar status de todos os leitos afetados
       leitosParaAtualizar.forEach(leitoId => {
+        if (!leitosIdSet.has(leitoId)) {
+          return;
+        }
         const leitoRef = doc(db, BEDS_COLLECTION_PATH, leitoId);
         const novoStatus = pacientesFinais[leitoId] ? 'Ocupado' : 'Vago';
         batch.update(leitoRef, {


### PR DESCRIPTION
## Summary
- ignore bed status updates for discharges tied to non-existent beds by validating IDs against the loaded bed map
- guard the final bed status update batch so only known bed IDs are updated

## Testing
- npm run lint *(fails: missing dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d584ba1fb883229fb98a54a6cc93f1