### PR TITLE
Refatora filtros e painel de regulações em andamento

### DIFF
--- a/src/components/FiltrosRegulacao.jsx
+++ b/src/components/FiltrosRegulacao.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import {
   Select,
   SelectContent,
@@ -11,6 +12,7 @@ import {
   SelectValue
 } from "@/components/ui/select";
 import { Filter, RotateCcw, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { ESPECIALIDADES_MEDICAS } from "@/lib/constants";
 
 const defaultFilters = {
   searchTerm: '',
@@ -24,16 +26,6 @@ const defaultFilters = {
 };
 
 const defaultSort = { key: 'nome', direction: 'asc' };
-
-const especialidadeOptions = [
-  { value: 'todos', label: 'Todas' },
-  { value: 'clinica', label: 'Clínica Médica' },
-  { value: 'cirurgia', label: 'Cirurgia' },
-  { value: 'cardiologia', label: 'Cardiologia' },
-  { value: 'neurologia', label: 'Neurologia' },
-  { value: 'ortopedia', label: 'Ortopedia' },
-  { value: 'pediatria', label: 'Pediatria' }
-];
 
 const sexoOptions = [
   { value: 'todos', label: 'Todos' },
@@ -55,6 +47,8 @@ const FiltrosRegulacao = ({
   initialFilters = defaultFilters,
   defaultSortConfig = defaultSort
 }) => {
+  const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
+
   const handleInputChange = (field) => (event) => {
     const value = event.target.value;
     setFiltros((prev) => ({
@@ -107,8 +101,8 @@ const FiltrosRegulacao = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="md:col-span-2">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="flex w-full flex-col gap-1 md:max-w-sm">
             <Label className="text-xs uppercase text-muted-foreground">Pesquisar por nome</Label>
             <Input
               placeholder="Digite o nome do paciente"
@@ -116,97 +110,8 @@ const FiltrosRegulacao = ({
               onChange={handleInputChange('searchTerm')}
             />
           </div>
-          <div>
-            <Label className="text-xs uppercase text-muted-foreground">Especialidade</Label>
-            <Select value={filtros.especialidade} onValueChange={handleSelectChange('especialidade')}>
-              <SelectTrigger>
-                <SelectValue placeholder="Todas" />
-              </SelectTrigger>
-              <SelectContent>
-                {especialidadeOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div>
-            <Label className="text-xs uppercase text-muted-foreground">Sexo</Label>
-            <Select value={filtros.sexo} onValueChange={handleSelectChange('sexo')}>
-              <SelectTrigger>
-                <SelectValue placeholder="Todos" />
-              </SelectTrigger>
-              <SelectContent>
-                {sexoOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label className="text-xs uppercase text-muted-foreground">Idade mínima</Label>
-            <Input
-              type="number"
-              min="0"
-              value={filtros.idadeMin}
-              onChange={handleInputChange('idadeMin')}
-              placeholder="Min"
-            />
-          </div>
-          <div>
-            <Label className="text-xs uppercase text-muted-foreground">Idade máxima</Label>
-            <Input
-              type="number"
-              min="0"
-              value={filtros.idadeMax}
-              onChange={handleInputChange('idadeMax')}
-              placeholder="Max"
-            />
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            <div className="col-span-1">
-              <Label className="text-xs uppercase text-muted-foreground">Tempo mín.</Label>
-              <Input
-                type="number"
-                min="0"
-                value={filtros.tempoInternacaoMin}
-                onChange={handleInputChange('tempoInternacaoMin')}
-                placeholder="0"
-              />
-            </div>
-            <div className="col-span-1">
-              <Label className="text-xs uppercase text-muted-foreground">Tempo máx.</Label>
-              <Input
-                type="number"
-                min="0"
-                value={filtros.tempoInternacaoMax}
-                onChange={handleInputChange('tempoInternacaoMax')}
-                placeholder="0"
-              />
-            </div>
-            <div className="col-span-1">
-              <Label className="text-xs uppercase text-muted-foreground">Unidade</Label>
-              <Select value={filtros.unidadeTempo} onValueChange={handleSelectChange('unidadeTempo')}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Dias" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="dias">Dias</SelectItem>
-                  <SelectItem value="horas">Horas</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 md:flex-1 md:justify-center">
             <span className="text-xs font-semibold uppercase text-muted-foreground">Ordenar por</span>
             {sortOptions.map((option) => {
               const isActive = sortConfig.key === option.key;
@@ -226,16 +131,125 @@ const FiltrosRegulacao = ({
             })}
           </div>
 
-          <Button
-            type="button"
-            variant="ghost"
-            className="gap-2 self-start"
-            onClick={handleClearFilters}
-          >
-            <RotateCcw className="h-4 w-4" />
-            Limpar filtros
-          </Button>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant={advancedFiltersOpen ? 'default' : 'outline'}
+              className="gap-2"
+              onClick={() => setAdvancedFiltersOpen((prev) => !prev)}
+              aria-expanded={advancedFiltersOpen}
+            >
+              <Filter className="h-4 w-4" />
+              Filtros Avançados
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="gap-2"
+              onClick={handleClearFilters}
+            >
+              <RotateCcw className="h-4 w-4" />
+              Limpar filtros
+            </Button>
+          </div>
         </div>
+
+        <Collapsible open={advancedFiltersOpen} onOpenChange={setAdvancedFiltersOpen}>
+          <CollapsibleContent className="space-y-4 rounded-md border border-dashed border-border bg-muted/20 p-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <div className="xl:col-span-2">
+                <Label className="text-xs uppercase text-muted-foreground">Especialidade</Label>
+                <Select value={filtros.especialidade} onValueChange={handleSelectChange('especialidade')}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Todas" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="todos">Todas</SelectItem>
+                    {ESPECIALIDADES_MEDICAS.map((especialidade) => (
+                      <SelectItem key={especialidade} value={especialidade}>
+                        {especialidade}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <Label className="text-xs uppercase text-muted-foreground">Sexo</Label>
+                <Select value={filtros.sexo} onValueChange={handleSelectChange('sexo')}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Todos" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sexoOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label className="text-xs uppercase text-muted-foreground">Idade mín.</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    value={filtros.idadeMin}
+                    onChange={handleInputChange('idadeMin')}
+                    placeholder="0"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs uppercase text-muted-foreground">Idade máx.</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    value={filtros.idadeMax}
+                    onChange={handleInputChange('idadeMax')}
+                    placeholder="0"
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2">
+                <div>
+                  <Label className="text-xs uppercase text-muted-foreground">Tempo mín.</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    value={filtros.tempoInternacaoMin}
+                    onChange={handleInputChange('tempoInternacaoMin')}
+                    placeholder="0"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs uppercase text-muted-foreground">Tempo máx.</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    value={filtros.tempoInternacaoMax}
+                    onChange={handleInputChange('tempoInternacaoMax')}
+                    placeholder="0"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs uppercase text-muted-foreground">Unidade</Label>
+                  <Select value={filtros.unidadeTempo} onValueChange={handleSelectChange('unidadeTempo')}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Dias" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="dias">Dias</SelectItem>
+                      <SelectItem value="horas">Horas</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       </CardContent>
     </Card>
   );

--- a/src/components/RegulacoesEmAndamentoPanel.jsx
+++ b/src/components/RegulacoesEmAndamentoPanel.jsx
@@ -2,8 +2,15 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Loader, ClipboardCopy, CheckCircle, Pencil, XCircle, FileText } from "lucide-react";
+import { Loader, ClipboardCopy, CheckCircle, Pencil, XCircle, FileText, MoreHorizontal } from "lucide-react";
 import { intervalToDuration, differenceInMinutes } from 'date-fns';
 import { 
   getSetoresCollection, 
@@ -521,112 +528,62 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
     }
   };
 
-  const RegulacaoCard = ({ paciente }) => {
+  const RegulacaoListItem = ({ paciente }) => {
     const { regulacaoAtiva } = paciente;
     const leitoOrigem = obterInfoLeito(regulacaoAtiva.leitoOrigemId);
     const leitoDestino = obterInfoLeito(regulacaoAtiva.leitoDestinoId);
     const tempoRegulacao = calcularTempoRegulacao(regulacaoAtiva.iniciadoEm);
 
     return (
-      <Card className="p-4 hover:shadow-md transition-shadow border border-muted">
-        <div className="space-y-3">
-          {/* Nome do Paciente */}
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex-1 min-w-0">
-              <h4 className="font-semibold text-sm leading-tight truncate">
-                {paciente.nomePaciente}
-              </h4>
-            </div>
-            <Badge variant="outline" className="text-xs font-medium bg-orange-100 text-orange-800 border-orange-300">
+      <div className="flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between md:gap-6">
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="truncate text-sm font-semibold leading-tight text-foreground">
+              {paciente.nomePaciente}
+            </h4>
+            <Badge variant="outline" className="border-orange-300 bg-orange-100 text-xs font-medium text-orange-800">
               Em Regulação
             </Badge>
           </div>
-
-          {/* Origem e Destino */}
-          <div className="text-xs text-muted-foreground space-y-1">
-            <div>
-              <span className="font-medium">DE: </span>
-              <span className="font-semibold">{leitoOrigem.siglaSetor} - {leitoOrigem.codigo}</span>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <div className="font-medium">
+              DE:{' '}
+              <span className="font-semibold text-foreground">{leitoOrigem.siglaSetor} - {leitoOrigem.codigo}</span>
             </div>
-            <div>
-              <span className="font-medium">PARA: </span>
-              <span className="font-semibold">{leitoDestino.siglaSetor} - {leitoDestino.codigo}</span>
+            <div className="font-medium">
+              PARA:{' '}
+              <span className="font-semibold text-foreground">{leitoDestino.siglaSetor} - {leitoDestino.codigo}</span>
             </div>
           </div>
-
-          {/* Tempo da Regulação */}
-          <div className="text-xs text-muted-foreground">
-            <span className="font-medium">{tempoRegulacao}</span>
-          </div>
-
-          {/* Ações */}
-          <div className="flex justify-end gap-2">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button 
-                    className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                    onClick={() => handleCopiarTexto(paciente)}
-                  >
-                    <ClipboardCopy className="h-4 w-4 text-muted-foreground" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Copiar Texto Personalizado</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button 
-                    className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                    onClick={() => setModalConcluir({ open: true, paciente })}
-                  >
-                    <CheckCircle className="h-4 w-4 text-green-600" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Concluir Regulação</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button 
-                    className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                    onClick={() => setModalAlterar({ isOpen: true, regulacao: paciente })}
-                  >
-                    <Pencil className="h-4 w-4 text-blue-600" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Alterar Regulação</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button 
-                    className="p-1.5 hover:bg-muted rounded-md transition-colors"
-                    onClick={() => setModalCancelar({ open: true, paciente })}
-                  >
-                    <XCircle className="h-4 w-4 text-destructive" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Cancelar Regulação</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
+          <div className="text-xs font-medium text-muted-foreground">{tempoRegulacao}</div>
         </div>
-      </Card>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 text-muted-foreground">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuItem onSelect={() => handleCopiarTexto(paciente)}>
+              <ClipboardCopy className="mr-2 h-4 w-4" />
+              Copiar texto personalizado
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setModalConcluir({ open: true, paciente })}>
+              <CheckCircle className="mr-2 h-4 w-4 text-green-600" />
+              Concluir regulação
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setModalAlterar({ isOpen: true, regulacao: paciente })}>
+              <Pencil className="mr-2 h-4 w-4 text-blue-600" />
+              Alterar regulação
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setModalCancelar({ open: true, paciente })}>
+              <XCircle className="mr-2 h-4 w-4 text-destructive" />
+              Cancelar regulação
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     );
   };
 
@@ -679,10 +636,12 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
               <p className="text-sm">Nenhuma regulação corresponde aos filtros aplicados</p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {regulacoesFiltradas.map((paciente) => (
-                <RegulacaoCard key={paciente.id} paciente={paciente} />
-              ))}
+            <div className="overflow-hidden rounded-lg border border-border">
+              <div className="divide-y divide-border">
+                {regulacoesFiltradas.map((paciente) => (
+                  <RegulacaoListItem key={paciente.id} paciente={paciente} />
+                ))}
+              </div>
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- reorganiza o cabeçalho de filtros com barra principal, botão de filtros avançados e opções padronizadas de especialidades
- migra o restante dos filtros para um painel recolhível com layout mais compacto
- substitui o grid de regulações por uma lista vertical com ações agrupadas em menu suspenso

## Testing
- npm run lint *(falha: avisos e erros já existentes em arquivos não alterados)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a8b8601c8322acc33720aa92d11a