### PR TITLE
feat: track user in audit logs

### DIFF
--- a/src/components/CentralHigienizacaoPage.jsx
+++ b/src/components/CentralHigienizacaoPage.jsx
@@ -201,7 +201,8 @@ const CentralHigienizacaoPage = () => {
 
       await logAction(
         'Central de Higienização',
-        `Higienização ${tipoDeLimpeza} iniciada no leito '${leito.codigoLeito}' por ${usuarioNome}.`
+        `Higienização ${tipoDeLimpeza} iniciada no leito '${leito.codigoLeito}' por ${usuarioNome}.`,
+        currentUser
       );
 
       toast({
@@ -259,7 +260,8 @@ const CentralHigienizacaoPage = () => {
 
       await logAction(
         'Central de Higienização',
-        `Higienização ${tipoHigienizacao} concluída no leito '${leito.codigoLeito}' por ${usuarioNome}.`
+        `Higienização ${tipoHigienizacao} concluída no leito '${leito.codigoLeito}' por ${usuarioNome}.`,
+        currentUser
       );
 
       toast({

--- a/src/components/FilaEsperaUTIPanel.jsx
+++ b/src/components/FilaEsperaUTIPanel.jsx
@@ -337,7 +337,8 @@ const FilaEsperaUTIPanel = ({ filtros, sortConfig }) => {
 
       await logAction(
         'Regulação de Leitos',
-        `Transferência externa ${acao} para o paciente '${paciente.nomePaciente}' por ${nomeUsuario}. Motivo: ${dados.motivo}, Destino: ${dados.destino}`
+        `Transferência externa ${acao} para o paciente '${paciente.nomePaciente}' por ${nomeUsuario}. Motivo: ${dados.motivo}, Destino: ${dados.destino}`,
+        currentUser
       );
 
       toast({
@@ -379,7 +380,8 @@ const FilaEsperaUTIPanel = ({ filtros, sortConfig }) => {
       const nomeUsuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
       await logAction(
         'Regulação de Leitos',
-        `Pedido de UTI do paciente '${paciente.nomePaciente}' foi cancelado por ${nomeUsuario}.`
+        `Pedido de UTI do paciente '${paciente.nomePaciente}' foi cancelado por ${nomeUsuario}.`,
+        currentUser
       );
 
       toast({

--- a/src/components/GerenciamentoLeitosModal.jsx
+++ b/src/components/GerenciamentoLeitosModal.jsx
@@ -29,6 +29,7 @@ import {
   serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
   // Estados para dados
@@ -70,6 +71,7 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
   const isEditandoLeito = itemEmEdicao?.tipo === 'leito';
   const isEditandoQuarto = itemEmEdicao?.tipo === 'quarto';
   const { toast } = useToast();
+  const { currentUser } = useAuth();
 
   // Listeners em tempo real
   useEffect(() => {
@@ -130,12 +132,12 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
       if (editingSetor) {
         await setDoc(doc(getSetoresCollection(), editingSetor), setorData);
         toast({ title: "Setor atualizado com sucesso!" });
-        await logAction('Gerenciamento de Leitos', `Setor '${setorData.nomeSetor}' foi atualizado.`);
+        await logAction('Gerenciamento de Leitos', `Setor '${setorData.nomeSetor}' foi atualizado.`, currentUser);
         setEditingSetor(null);
       } else {
         await addDoc(getSetoresCollection(), setorData);
         toast({ title: "Setor criado com sucesso!" });
-        await logAction('Gerenciamento de Leitos', `Setor '${setorData.nomeSetor}' foi criado.`);
+        await logAction('Gerenciamento de Leitos', `Setor '${setorData.nomeSetor}' foi criado.`, currentUser);
       }
 
       setSetorForm({ id: '', nomeSetor: '', siglaSetor: '', tipoSetor: '' });
@@ -168,7 +170,7 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
       const setor = setores.find(s => s.id === setorId);
       await deleteDoc(doc(getSetoresCollection(), setorId));
       toast({ title: "Setor excluído com sucesso!" });
-      await logAction('Gerenciamento de Leitos', `Setor '${setor?.nomeSetor || setorId}' foi excluído.`);
+      await logAction('Gerenciamento de Leitos', `Setor '${setor?.nomeSetor || setorId}' foi excluído.`, currentUser);
     } catch (error) {
       toast({ 
         title: "Erro ao excluir setor", 
@@ -237,7 +239,7 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
 
         const setorNome = setores.find(s => s.id === leitoForm.setorId)?.nomeSetor || leitoForm.setorId;
         toast({ title: `${codigos.length} leito(s) criado(s) com sucesso!` });
-        await logAction('Gerenciamento de Leitos', `${codigos.length} leito(s) foram criados no setor '${setorNome}'.`);
+        await logAction('Gerenciamento de Leitos', `${codigos.length} leito(s) foram criados no setor '${setorNome}'.`, currentUser);
       }
 
       setLeitoForm({ setorId: '', codigosLeitos: '', isPCP: false });
@@ -280,7 +282,7 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
       const leito = leitos.find(l => l.id === leitoId);
       await deleteDoc(doc(getLeitosCollection(), leitoId));
       toast({ title: "Leito excluído com sucesso!" });
-      await logAction('Gerenciamento de Leitos', `Leito '${leito?.codigoLeito || leitoId}' foi excluído.`);
+      await logAction('Gerenciamento de Leitos', `Leito '${leito?.codigoLeito || leitoId}' foi excluído.`, currentUser);
     } catch (error) {
       toast({ 
         title: "Erro ao excluir leito", 
@@ -317,11 +319,11 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
         const quartoRef = doc(getQuartosCollection(), itemEmEdicao.id);
         await updateDoc(quartoRef, quartoData);
         toast({ title: "Quarto atualizado com sucesso!" });
-        await logAction('Gerenciamento de Leitos', `Quarto '${quartoData.nomeQuarto}' foi atualizado.`);
+        await logAction('Gerenciamento de Leitos', `Quarto '${quartoData.nomeQuarto}' foi atualizado.`, currentUser);
       } else {
         await addDoc(getQuartosCollection(), quartoData);
         toast({ title: "Quarto criado com sucesso!" });
-        await logAction('Gerenciamento de Leitos', `Quarto '${quartoData.nomeQuarto}' foi criado.`);
+        await logAction('Gerenciamento de Leitos', `Quarto '${quartoData.nomeQuarto}' foi criado.`, currentUser);
       }
 
       handleCancelarEdicaoQuarto();
@@ -360,7 +362,7 @@ const GerenciamentoLeitosModal = ({ isOpen, onClose }) => {
       const quarto = quartos.find(q => q.id === quartoId);
       await deleteDoc(doc(getQuartosCollection(), quartoId));
       toast({ title: "Quarto excluído com sucesso!" });
-      await logAction('Gerenciamento de Leitos', `Quarto '${quarto?.nomeQuarto || quartoId}' foi excluído.`);
+      await logAction('Gerenciamento de Leitos', `Quarto '${quarto?.nomeQuarto || quartoId}' foi excluído.`, currentUser);
     } catch (error) {
       toast({
         title: "Erro ao excluir quarto",

--- a/src/components/GestaoIsolamentosPage.jsx
+++ b/src/components/GestaoIsolamentosPage.jsx
@@ -25,6 +25,7 @@ import {
   serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import GerenciarInfeccoesModal from './modals/GerenciarInfeccoesModal';
@@ -50,6 +51,7 @@ const GestaoIsolamentosPage = () => {
   const [showDescartarIsolamento, setShowDescartarIsolamento] = useState(false);
   const [showFinalizarIsolamento, setShowFinalizarIsolamento] = useState(false);
   const [showAlterarData, setShowAlterarData] = useState(false);
+  const { currentUser } = useAuth();
   
   // Estados para ações específicas
   const [isolamentoSelecionado, setIsolamentoSelecionado] = useState(null);
@@ -340,7 +342,8 @@ const GestaoIsolamentosPage = () => {
 
           await logAction(
             'Gestão de Isolamentos',
-            `Pedido de remanejamento automático criado para o paciente '${paciente.nomePaciente}' devido a risco de contaminação.`
+            `Pedido de remanejamento automático criado para o paciente '${paciente.nomePaciente}' devido a risco de contaminação.`,
+            currentUser
           );
         } catch (error) {
           console.error('Erro ao criar pedido automático de remanejamento:', error);
@@ -365,7 +368,8 @@ const GestaoIsolamentosPage = () => {
 
           await logAction(
             'Gestão de Isolamentos',
-            `Pedido de remanejamento automático do paciente '${paciente.nomePaciente}' foi resolvido.`
+            `Pedido de remanejamento automático do paciente '${paciente.nomePaciente}' foi resolvido.`,
+            currentUser
           );
         } catch (error) {
           console.error('Erro ao resolver pedido automático de remanejamento:', error);

--- a/src/components/GestaoPacientesPage.jsx
+++ b/src/components/GestaoPacientesPage.jsx
@@ -44,6 +44,7 @@ import {
   serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/components/ui/use-toast';
 import { format, parseISO } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -58,6 +59,7 @@ const GestaoPacientesPage = () => {
   const [setores, setSetores] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
+  const { currentUser } = useAuth();
 
   // Modal states
   const [visualizarPaciente, setVisualizarPaciente] = useState(null);
@@ -137,7 +139,7 @@ const GestaoPacientesPage = () => {
       await updateDoc(pacienteRef, dadosAtualizados);
 
       const paciente = pacientes.find(p => p.id === pacienteId);
-      await logAction('Gestão de Pacientes', `Dados do paciente '${paciente?.nomeCompleto}' foram atualizados.`);
+      await logAction('Gestão de Pacientes', `Dados do paciente '${paciente?.nomeCompleto}' foram atualizados.`, currentUser);
       
       toast({
         title: "Sucesso",
@@ -181,7 +183,7 @@ const GestaoPacientesPage = () => {
 
       await batch.commit();
 
-      await logAction('Gestão de Pacientes', `Paciente '${paciente.nomeCompleto}' foi excluído do sistema.`);
+      await logAction('Gestão de Pacientes', `Paciente '${paciente.nomeCompleto}' foi excluído do sistema.`, currentUser);
       
       toast({
         title: "Sucesso",
@@ -241,8 +243,9 @@ const GestaoPacientesPage = () => {
 
       await batch.commit();
 
-      await logAction('Gestão de Pacientes', 
-        `LIMPEZA GERAL EXECUTADA: ${totalPacientesRemovidos} pacientes removidos e ${totalLeitosLiberados} leitos liberados.`
+      await logAction('Gestão de Pacientes',
+        `LIMPEZA GERAL EXECUTADA: ${totalPacientesRemovidos} pacientes removidos e ${totalLeitosLiberados} leitos liberados.`,
+        currentUser
       );
       
       toast({

--- a/src/components/GestaoUsuariosPage.jsx
+++ b/src/components/GestaoUsuariosPage.jsx
@@ -37,6 +37,7 @@ import {
   db
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 // Lista de páginas disponíveis para permissões
 const PAGINAS_DISPONIVEIS = [
@@ -76,6 +77,7 @@ const ModalUsuario = ({ isOpen, onClose, modo, usuario, onSave }) => {
   const [permissoesSelecionadas, setPermissoesSelecionadas] = useState([]);
   const [loading, setLoading] = useState(false);
   const tipoUsuarioSelecionado = watch('tipoUsuario');
+  const { currentUser } = useAuth();
 
   // Carregar dados do usuário quando for edição/visualização
   useEffect(() => {
@@ -178,7 +180,7 @@ const ModalUsuario = ({ isOpen, onClose, modo, usuario, onSave }) => {
         dadosUsuario.uid = userCredential.user.uid;
         await addDoc(getUsuariosCollection(), dadosUsuario);
 
-        await logAction('Gestão de Usuários', `Usuário criado: ${dadosUsuario.nomeCompleto} (${dadosUsuario.emailInstitucional})`);
+        await logAction('Gestão de Usuários', `Usuário criado: ${dadosUsuario.nomeCompleto} (${dadosUsuario.emailInstitucional})`, currentUser);
         
         toast({
           title: "Usuário criado",
@@ -189,7 +191,7 @@ const ModalUsuario = ({ isOpen, onClose, modo, usuario, onSave }) => {
         const docRef = doc(getUsuariosCollection(), usuario.id);
         await setDoc(docRef, dadosUsuario, { merge: true });
 
-        await logAction('Gestão de Usuários', `Usuário editado: ${dadosUsuario.nomeCompleto} (${dadosUsuario.emailInstitucional})`);
+        await logAction('Gestão de Usuários', `Usuário editado: ${dadosUsuario.nomeCompleto} (${dadosUsuario.emailInstitucional})`, currentUser);
         
         toast({
           title: "Usuário atualizado",
@@ -349,6 +351,7 @@ const GestaoUsuariosPage = () => {
   const [modoModal, setModoModal] = useState('criar');
   const [usuarioSelecionado, setUsuarioSelecionado] = useState(null);
   const [loading, setLoading] = useState(true);
+  const { currentUser } = useAuth();
 
   // Buscar usuários em tempo real
   useEffect(() => {
@@ -397,7 +400,7 @@ const GestaoUsuariosPage = () => {
       const docRef = doc(getUsuariosCollection(), usuario.id);
       await deleteDoc(docRef);
 
-      await logAction('Gestão de Usuários', `Usuário excluído: ${usuario.nomeCompleto} (${usuario.emailInstitucional})`);
+      await logAction('Gestão de Usuários', `Usuário excluído: ${usuario.nomeCompleto} (${usuario.emailInstitucional})`, currentUser);
 
       toast({
         title: "Usuário excluído",

--- a/src/components/ImportarPacientesMVModal.jsx
+++ b/src/components/ImportarPacientesMVModal.jsx
@@ -40,6 +40,7 @@ import {
 } from '@/lib/firebase-constants';
 import { writeBatch } from 'firebase/firestore';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 
 const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
@@ -54,6 +55,8 @@ const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
     novosSetores: 0,
     novosLeitos: 0
   });
+
+  const { currentUser } = useAuth();
 
   // Novos estados para validação
   const [setoresFaltantes, setSetoresFaltantes] = useState([]);
@@ -680,7 +683,7 @@ const ImportarPacientesMVModal = ({ isOpen, onClose }) => {
 
       logMessage += '.';
 
-      await logAction('Regulação de Leitos', logMessage);
+      await logAction('Regulação de Leitos', logMessage, currentUser);
 
       setCurrentStep('completed');
 

--- a/src/components/MapaLeitosPanel.jsx
+++ b/src/components/MapaLeitosPanel.jsx
@@ -49,6 +49,7 @@ import {
   deleteDoc
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 import LiberarLeitoModal from './modals/LiberarLeitoModal';
 import ObservacoesModal from './modals/ObservacoesModal';
@@ -92,6 +93,7 @@ const LeitoCard = ({
   onInternarManual
 }) => {
   const { toast } = useToast();
+  const { currentUser } = useAuth();
 
   const formatRegulacaoTempo = (valor) => {
     if (!valor) return null;
@@ -687,6 +689,7 @@ const MapaLeitosPanel = () => {
   const [leitos, setLeitos] = useState([]);
   const [pacientes, setPacientes] = useState([]);
   const [infeccoes, setInfeccoes] = useState([]);
+  const { currentUser } = useAuth();
   const [loading, setLoading] = useState(true);
   const [expandedSections, setExpandedSections] = useState({});
   const [expandedSetores, setExpandedSetores] = useState({});
@@ -780,7 +783,7 @@ const MapaLeitosPanel = () => {
           timestamp: new Date()
         })
       });
-      await logAction('Mapa de Leitos', `Leito '${modalBloquear.leito.codigoLeito}' foi bloqueado. Motivo: '${motivoBloqueio.trim()}'.`);
+      await logAction('Mapa de Leitos', `Leito '${modalBloquear.leito.codigoLeito}' foi bloqueado. Motivo: '${motivoBloqueio.trim()}'.`, currentUser);
       
       toast({
         title: "Leito bloqueado",
@@ -810,7 +813,7 @@ const MapaLeitosPanel = () => {
           timestamp: new Date()
         })
       });
-      await logAction('Mapa de Leitos', `Solicitada higienização para o leito '${leito.codigoLeito}'.`);
+      await logAction('Mapa de Leitos', `Solicitada higienização para o leito '${leito.codigoLeito}'.`, currentUser);
       
       toast({
         title: "Higienização solicitada",
@@ -839,7 +842,7 @@ const MapaLeitosPanel = () => {
           timestamp: new Date()
         })
       });
-      await logAction('Mapa de Leitos', `Leito '${leito.codigoLeito}' foi desbloqueado.`);
+      await logAction('Mapa de Leitos', `Leito '${leito.codigoLeito}' foi desbloqueado.`, currentUser);
       
       toast({
         title: "Leito desbloqueado",
@@ -868,7 +871,7 @@ const MapaLeitosPanel = () => {
           timestamp: new Date()
         })
       });
-      await logAction('Mapa de Leitos', `Higienização do leito '${leito.codigoLeito}' foi finalizada.`);
+      await logAction('Mapa de Leitos', `Higienização do leito '${leito.codigoLeito}' foi finalizada.`, currentUser);
       
       toast({
         title: "Higienização finalizada",
@@ -894,7 +897,8 @@ const MapaLeitosPanel = () => {
       });
       await logAction('Mapa de Leitos', !leito.higienizacaoPrioritaria
         ? `Higienização do leito '${leito.codigoLeito}' foi marcada como prioritária.`
-        : `Prioridade de higienização do leito '${leito.codigoLeito}' foi removida.`
+        : `Prioridade de higienização do leito '${leito.codigoLeito}' foi removida.`,
+        currentUser
       );
       
       toast({
@@ -928,7 +932,7 @@ const MapaLeitosPanel = () => {
         })
       });
       
-      await logAction('Mapa de Leitos', `Leito '${leito.codigoLeito}' foi liberado. Paciente '${paciente.nomePaciente}' foi dado alta.`);
+      await logAction('Mapa de Leitos', `Leito '${leito.codigoLeito}' foi liberado. Paciente '${paciente.nomePaciente}' foi dado alta.`, currentUser);
       
       toast({
         title: "Leito liberado",
@@ -959,7 +963,7 @@ const MapaLeitosPanel = () => {
           description: "Pedido de UTI foi removido.",
         });
         
-        await logAction('Mapa de Leitos', `Pedido de UTI do paciente '${paciente.nomePaciente}' foi removido.`);
+        await logAction('Mapa de Leitos', `Pedido de UTI do paciente '${paciente.nomePaciente}' foi removido.`, currentUser);
       } else {
         // Adicionar pedido de UTI
         await updateDoc(pacienteRef, {
@@ -973,7 +977,7 @@ const MapaLeitosPanel = () => {
           description: "Pedido de UTI foi registrado.",
         });
         
-        await logAction('Mapa de Leitos', `UTI solicitada para o paciente '${paciente.nomePaciente}'.`);
+        await logAction('Mapa de Leitos', `UTI solicitada para o paciente '${paciente.nomePaciente}'.`, currentUser);
       }
     } catch (error) {
       console.error('Erro ao gerenciar pedido de UTI:', error);
@@ -1000,7 +1004,7 @@ const MapaLeitosPanel = () => {
           description: "Registro de provável alta foi removido.",
         });
         
-        await logAction('Mapa de Leitos', `Provável alta do paciente '${paciente.nomePaciente}' foi removida.`);
+        await logAction('Mapa de Leitos', `Provável alta do paciente '${paciente.nomePaciente}' foi removida.`, currentUser);
       } else {
         // Adicionar provável alta
         await updateDoc(pacienteRef, {
@@ -1014,7 +1018,7 @@ const MapaLeitosPanel = () => {
           description: "Provável alta foi sinalizada.",
         });
         
-        await logAction('Mapa de Leitos', `Provável alta sinalizada para o paciente '${paciente.nomePaciente}'.`);
+        await logAction('Mapa de Leitos', `Provável alta sinalizada para o paciente '${paciente.nomePaciente}'.`, currentUser);
       }
     } catch (error) {
       console.error('Erro ao gerenciar provável alta:', error);
@@ -1041,7 +1045,7 @@ const MapaLeitosPanel = () => {
           description: "Registro de alta no leito foi removido.",
         });
         
-        await logAction('Mapa de Leitos', `Alta no leito do paciente '${paciente.nomePaciente}' foi removida.`);
+        await logAction('Mapa de Leitos', `Alta no leito do paciente '${paciente.nomePaciente}' foi removida.`, currentUser);
       } else {
         // Abrir modal para coletar dados
         setModalAltaNoLeito({ open: true, paciente });
@@ -1073,7 +1077,7 @@ const MapaLeitosPanel = () => {
         description: "Nova observação foi registrada.",
       });
       
-      await logAction('Mapa de Leitos', `Nova observação adicionada para o paciente '${modalObservacoes.paciente.nomePaciente}'.`);
+      await logAction('Mapa de Leitos', `Nova observação adicionada para o paciente '${modalObservacoes.paciente.nomePaciente}'.`, currentUser);
       
       setModalObservacoes({ open: false, paciente: null });
     } catch (error) {
@@ -1133,8 +1137,9 @@ const MapaLeitosPanel = () => {
         description: `Paciente ${paciente.nomePaciente} foi movido para o leito ${leitoDestino.codigoLeito}.`,
       });
       
-      await logAction('Mapa de Leitos', 
-        `Paciente '${paciente.nomePaciente}' foi movido do leito '${leitoOrigem.codigoLeito}' para o leito '${leitoDestino.codigoLeito}'.`
+      await logAction('Mapa de Leitos',
+        `Paciente '${paciente.nomePaciente}' foi movido do leito '${leitoOrigem.codigoLeito}' para o leito '${leitoDestino.codigoLeito}'.`,
+        currentUser
       );
       
       setModalMoverPaciente({ open: false, leito: null, paciente: null });
@@ -1165,8 +1170,9 @@ const MapaLeitosPanel = () => {
         description: "Pedido de remanejamento foi registrado.",
       });
       
-      await logAction('Mapa de Leitos', 
-        `Remanejamento solicitado para o paciente '${modalRemanejamento.paciente.nomePaciente}'. Motivo: ${dados.tipo}`
+      await logAction('Mapa de Leitos',
+        `Remanejamento solicitado para o paciente '${modalRemanejamento.paciente.nomePaciente}'. Motivo: ${dados.tipo}`,
+        currentUser
       );
       
       setModalRemanejamento({ open: false, paciente: null });
@@ -1198,8 +1204,9 @@ const MapaLeitosPanel = () => {
         description: "Pedido de transferência externa foi registrado.",
       });
       
-      await logAction('Mapa de Leitos', 
-        `Transferência externa solicitada para o paciente '${modalTransferenciaExterna.paciente.nomePaciente}'. Motivo: ${dados.motivo}, Destino: ${dados.destino}`
+      await logAction('Mapa de Leitos',
+        `Transferência externa solicitada para o paciente '${modalTransferenciaExterna.paciente.nomePaciente}'. Motivo: ${dados.motivo}, Destino: ${dados.destino}`,
+        currentUser
       );
       
       setModalTransferenciaExterna({ open: false, paciente: null });
@@ -1230,8 +1237,9 @@ const MapaLeitosPanel = () => {
         description: "Alta no leito foi sinalizada.",
       });
       
-      await logAction('Mapa de Leitos', 
-        `Alta no leito sinalizada para o paciente '${modalAltaNoLeito.paciente.nomePaciente}'. Motivo: ${dados.motivo}`
+      await logAction('Mapa de Leitos',
+        `Alta no leito sinalizada para o paciente '${modalAltaNoLeito.paciente.nomePaciente}'. Motivo: ${dados.motivo}`,
+        currentUser
       );
       
       setModalAltaNoLeito({ open: false, paciente: null });

--- a/src/components/RegulacoesEmAndamentoPanel.jsx
+++ b/src/components/RegulacoesEmAndamentoPanel.jsx
@@ -435,8 +435,9 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
       // Auditoria detalhada
       const nomeUsuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
       await logAction(
-        'Regulação de Leitos', 
-        `Regulação para o paciente '${paciente.nomePaciente}' (do leito ${leitoOrigem.siglaSetor} - ${leitoOrigem.codigo} para ${leitoDestino.siglaSetor} - ${leitoDestino.codigo}) foi concluída por ${nomeUsuario} em ${tempoRegulacao} minutos.`
+        'Regulação de Leitos',
+        `Regulação para o paciente '${paciente.nomePaciente}' (do leito ${leitoOrigem.siglaSetor} - ${leitoOrigem.codigo} para ${leitoDestino.siglaSetor} - ${leitoDestino.codigo}) foi concluída por ${nomeUsuario} em ${tempoRegulacao} minutos.`,
+        currentUser
       );
       
       // Log condicional de UTI
@@ -445,7 +446,8 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
         const tempoEspera = differenceInMinutes(new Date(), inicioUTI);
         await logAction(
           'Regulação de Leitos',
-          `Pedido de UTI do paciente '${paciente.nomePaciente}' foi atendido. Tempo de espera: ${tempoEspera} minutos.`
+          `Pedido de UTI do paciente '${paciente.nomePaciente}' foi atendido. Tempo de espera: ${tempoEspera} minutos.`,
+          currentUser
         );
       }
       
@@ -508,7 +510,8 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
       const nomeUsuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
       await logAction(
         'Regulação de Leitos',
-        `Regulação para o paciente '${paciente.nomePaciente}' (do leito ${leitoOrigem.siglaSetor} - ${leitoOrigem.codigo} para ${leitoDestino.siglaSetor} - ${leitoDestino.codigo}) foi CANCELADA por ${nomeUsuario}. Motivo: '${justificativa}'.`
+        `Regulação para o paciente '${paciente.nomePaciente}' (do leito ${leitoOrigem.siglaSetor} - ${leitoOrigem.codigo} para ${leitoDestino.siglaSetor} - ${leitoDestino.codigo}) foi CANCELADA por ${nomeUsuario}. Motivo: '${justificativa}'.`,
+        currentUser
       );
       
       toast({

--- a/src/components/RemanejamentosPendentesPanel.jsx
+++ b/src/components/RemanejamentosPendentesPanel.jsx
@@ -336,7 +336,8 @@ const RemanejamentosPendentesPanel = ({ filtros, sortConfig }) => {
       const nomeUsuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
       await logAction(
         'Regulação de Leitos',
-        `Pedido de remanejamento para o paciente '${paciente.nomePaciente}' foi cancelado por ${nomeUsuario}.`
+        `Pedido de remanejamento para o paciente '${paciente.nomePaciente}' foi cancelado por ${nomeUsuario}.`,
+        currentUser
       );
 
       toast({

--- a/src/components/TransferenciaExternaPanel.jsx
+++ b/src/components/TransferenciaExternaPanel.jsx
@@ -298,7 +298,8 @@ const TransferenciaExternaPanel = ({ filtros, sortConfig }) => {
 
       await logAction(
         'Regulação de Leitos',
-        `Transferência externa ${acao} para o paciente '${paciente.nomePaciente}' por ${nomeUsuario}. Motivo: ${dados.motivo}, Destino: ${dados.destino}`
+        `Transferência externa ${acao} para o paciente '${paciente.nomePaciente}' por ${nomeUsuario}. Motivo: ${dados.motivo}, Destino: ${dados.destino}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/AlterarDataIsolamentoModal.jsx
+++ b/src/components/modals/AlterarDataIsolamentoModal.jsx
@@ -15,11 +15,13 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const AlterarDataIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => {
   const [novaData, setNovaData] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { currentUser } = useAuth();
 
   React.useEffect(() => {
     if (isolamento && isOpen) {
@@ -64,7 +66,8 @@ const AlterarDataIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) =
 
       await logAction(
         "Gestão de Isolamentos",
-        `Data de isolamento alterada para ${paciente.nomePaciente}: nova data ${format(novaData, 'dd/MM/yyyy', { locale: ptBR })}`
+        `Data de isolamento alterada para ${paciente.nomePaciente}: nova data ${format(novaData, 'dd/MM/yyyy', { locale: ptBR })}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/AlterarRegulacaoModal.jsx
+++ b/src/components/modals/AlterarRegulacaoModal.jsx
@@ -161,7 +161,7 @@ const AlterarRegulacaoModal = ({ isOpen, onClose, regulacao }) => {
       const usuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
       const destAnteriorStr = `${destinoAtualInfo?.siglaSetor} - ${destinoAtualInfo?.codigo}`;
       const novoDestinoStr = `${dados.setores.find(s => s.id === novoLeito.setorId)?.siglaSetor || 'N/A'} - ${novoLeito.codigoLeito}`;
-      await logAction('Regulação de Leitos', `Regulação do paciente '${paciente.nomePaciente}' foi ALTERADA por ${usuario} do leito '${destAnteriorStr}' para '${novoDestinoStr}'. Motivo: '${justificativa}'.`);
+      await logAction('Regulação de Leitos', `Regulação do paciente '${paciente.nomePaciente}' foi ALTERADA por ${usuario} do leito '${destAnteriorStr}' para '${novoDestinoStr}'. Motivo: '${justificativa}'.`, currentUser);
 
       toast({ title: 'Regulação alterada', description: 'A alteração foi aplicada com sucesso.' });
       fechar();

--- a/src/components/modals/CancelarReservaExternaModal.jsx
+++ b/src/components/modals/CancelarReservaExternaModal.jsx
@@ -22,11 +22,13 @@ import {
   arrayUnion
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const CancelarReservaExternaModal = ({ isOpen, onClose, reserva, leito }) => {
   const { toast } = useToast();
   const [decisao, setDecisao] = useState('fila');
   const [carregando, setCarregando] = useState(false);
+  const { currentUser } = useAuth();
 
   useEffect(() => {
     if (!isOpen) {
@@ -72,7 +74,8 @@ const CancelarReservaExternaModal = ({ isOpen, onClose, reserva, leito }) => {
         'Reservas de Leitos',
         decisao === 'fila'
           ? `Reserva externa devolvida para a fila: ${reserva.nomeCompleto}`
-          : `Reserva externa cancelada permanentemente: ${reserva.nomeCompleto}`
+          : `Reserva externa cancelada permanentemente: ${reserva.nomeCompleto}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/CancelarReservaModal.jsx
+++ b/src/components/modals/CancelarReservaModal.jsx
@@ -21,11 +21,13 @@ import {
   deleteField
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const CancelarReservaModal = ({ isOpen, onClose, reserva }) => {
   const { toast } = useToast();
   const [justificativa, setJustificativa] = useState('');
   const [cancelando, setCancelando] = useState(false);
+  const { currentUser } = useAuth();
 
   if (!reserva) return null;
 
@@ -47,7 +49,7 @@ const CancelarReservaModal = ({ isOpen, onClose, reserva }) => {
       const observacao = {
         texto: `RESERVA CANCELADA - ${justificativa.trim()}`,
         data: serverTimestamp(),
-        usuarioNome: 'Usuário do Sistema' // TODO: Pegar do contexto de auth
+        usuarioNome: currentUser?.nomeCompleto || 'Sistema'
       };
 
       // Atualizar reserva
@@ -70,7 +72,8 @@ const CancelarReservaModal = ({ isOpen, onClose, reserva }) => {
 
       await logAction(
         'Reservas de Leitos',
-        `Reserva de leito cancelada: ${reserva.nomeCompleto} - ${justificativa.trim()}`
+        `Reserva de leito cancelada: ${reserva.nomeCompleto} - ${justificativa.trim()}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/ConfirmarInternacaoExternaModal.jsx
+++ b/src/components/modals/ConfirmarInternacaoExternaModal.jsx
@@ -37,10 +37,12 @@ import {
   db
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { ESPECIALIDADES_MEDICAS } from '@/lib/constants';
 
 const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) => {
   const { toast } = useToast();
+  const { currentUser } = useAuth();
   const [alertaConfirmacaoAberto, setAlertaConfirmacaoAberto] = useState(false);
   const [formAberto, setFormAberto] = useState(false);
   const [processando, setProcessando] = useState(false);
@@ -213,7 +215,8 @@ const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) =>
 
       await logAction(
         'Reservas de Leitos',
-        `Internação confirmada para reserva externa: ${reserva.nomeCompleto}`
+        `Internação confirmada para reserva externa: ${reserva.nomeCompleto}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/ConfirmarInternacaoModal.jsx
+++ b/src/components/modals/ConfirmarInternacaoModal.jsx
@@ -38,6 +38,7 @@ import {
 } from '@/lib/firebase';
 import { getPacientesCollection, getLeitosCollection } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { ESPECIALIDADES_MEDICAS } from '@/lib/constants';
 
 const ConfirmarInternacaoModal = ({ isOpen, onClose, reserva }) => {
@@ -45,6 +46,7 @@ const ConfirmarInternacaoModal = ({ isOpen, onClose, reserva }) => {
   const [showAlertDialog, setShowAlertDialog] = useState(false);
   const [showFormDialog, setShowFormDialog] = useState(false);
   const [internando, setInternando] = useState(false);
+  const { currentUser } = useAuth();
 
   // Dados da internação
   const [dadosInternacao, setDadosInternacao] = useState({
@@ -145,7 +147,8 @@ const ConfirmarInternacaoModal = ({ isOpen, onClose, reserva }) => {
 
       await logAction(
         'Reservas de Leitos',
-        `Internação confirmada: ${reserva.nomeCompleto} - Especialidade: ${dadosInternacao.especialidade}`
+        `Internação confirmada: ${reserva.nomeCompleto} - Especialidade: ${dadosInternacao.especialidade}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/ConfirmarIsolamentoModal.jsx
+++ b/src/components/modals/ConfirmarIsolamentoModal.jsx
@@ -10,11 +10,13 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const ConfirmarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => {
   const [loading, setLoading] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { currentUser } = useAuth();
 
   const handleConfirmar = async () => {
     if (!paciente || !isolamento) return;
@@ -35,7 +37,8 @@ const ConfirmarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => 
 
       await logAction(
         "Gestão de Isolamentos",
-        `Isolamento confirmado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`
+        `Isolamento confirmado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/ConfirmarRegulacaoModal.jsx
+++ b/src/components/modals/ConfirmarRegulacaoModal.jsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/firebase';
 import { db, getLeitosCollection, getPacientesCollection } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const ConfirmarRegulacaoModal = ({ 
   isOpen, 
@@ -31,6 +32,7 @@ const ConfirmarRegulacaoModal = ({
 }) => {
   const [observacoes, setObservacoes] = useState('');
   const [processando, setProcessando] = useState(false);
+  const { currentUser } = useAuth();
 
   // Gerar mensagem formatada para WhatsApp
   const mensagemWhatsApp = useMemo(() => {
@@ -167,7 +169,8 @@ const ConfirmarRegulacaoModal = ({
       // Log de auditoria
       await logAction(
         'Regulação de Leitos',
-        `Regulação iniciada para o paciente '${paciente.nomePaciente}' do leito '${leitoOrigem.codigoLeito}' para o leito '${leitoDestino.codigoLeito}'`
+        `Regulação iniciada para o paciente '${paciente.nomePaciente}' do leito '${leitoOrigem.codigoLeito}' para o leito '${leitoDestino.codigoLeito}'`,
+        currentUser
       );
 
       // Mostrar toast de sucesso

--- a/src/components/modals/DescartarIsolamentoModal.jsx
+++ b/src/components/modals/DescartarIsolamentoModal.jsx
@@ -10,11 +10,13 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const DescartarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => {
   const [loading, setLoading] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { currentUser } = useAuth();
 
   const handleDescartar = async () => {
     if (!paciente || !isolamento) return;
@@ -33,7 +35,8 @@ const DescartarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => 
 
       await logAction(
         "Gestão de Isolamentos",
-        `Isolamento descartado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`
+        `Isolamento descartado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/FinalizarIsolamentoModal.jsx
+++ b/src/components/modals/FinalizarIsolamentoModal.jsx
@@ -10,11 +10,13 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const FinalizarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => {
   const [loading, setLoading] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const { currentUser } = useAuth();
 
   const handleFinalizar = async () => {
     if (!paciente || !isolamento) return;
@@ -33,7 +35,8 @@ const FinalizarIsolamentoModal = ({ isOpen, onClose, paciente, isolamento }) => 
 
       await logAction(
         "Gestão de Isolamentos",
-        `Isolamento finalizado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`
+        `Isolamento finalizado para ${paciente.nomePaciente}: infecção ${isolamento.infeccaoId}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/GerenciarInfeccoesModal.jsx
+++ b/src/components/modals/GerenciarInfeccoesModal.jsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const GerenciarInfeccoesModal = ({ isOpen, onClose, infeccoes }) => {
@@ -24,6 +25,7 @@ const GerenciarInfeccoesModal = ({ isOpen, onClose, infeccoes }) => {
     siglaInfeccao: ''
   });
   const [loading, setLoading] = useState(false);
+  const { currentUser } = useAuth();
 
   const resetForm = () => {
     setNovaInfeccao({
@@ -57,7 +59,8 @@ const GerenciarInfeccoesModal = ({ isOpen, onClose, infeccoes }) => {
 
       await logAction(
         "Gestão de Isolamentos",
-        `Nova infecção cadastrada: ${novaInfeccao.nomeInfeccao} (${novaInfeccao.siglaInfeccao})`
+        `Nova infecção cadastrada: ${novaInfeccao.nomeInfeccao} (${novaInfeccao.siglaInfeccao})`,
+        currentUser
       );
 
       toast({
@@ -98,7 +101,8 @@ const GerenciarInfeccoesModal = ({ isOpen, onClose, infeccoes }) => {
 
       await logAction(
         "Gestão de Isolamentos",
-        `Infecção editada: ${novaInfeccao.nomeInfeccao} (${novaInfeccao.siglaInfeccao})`
+        `Infecção editada: ${novaInfeccao.nomeInfeccao} (${novaInfeccao.siglaInfeccao})`,
+        currentUser
       );
 
       toast({
@@ -127,7 +131,8 @@ const GerenciarInfeccoesModal = ({ isOpen, onClose, infeccoes }) => {
 
       await logAction(
         "Gestão de Isolamentos",
-        `Infecção excluída: ${infeccao.nomeInfeccao} (${infeccao.siglaInfeccao})`
+        `Infecção excluída: ${infeccao.nomeInfeccao} (${infeccao.siglaInfeccao})`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/GerenciarIsolamentosModal.jsx
+++ b/src/components/modals/GerenciarIsolamentosModal.jsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/firebase';
 import { db } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
 
 const GerenciarIsolamentosModal = ({ isOpen, onClose, pacientes, infeccoes }) => {
@@ -33,6 +34,7 @@ const GerenciarIsolamentosModal = ({ isOpen, onClose, pacientes, infeccoes }) =>
   const [infeccoesSelecionadas, setInfeccoesSelecionadas] = useState([]);
   const [dadosIsolamentos, setDadosIsolamentos] = useState({});
   const [loading, setLoading] = useState(false);
+  const { currentUser } = useAuth();
 
   const resetForm = () => {
     setEtapa(1);
@@ -122,7 +124,8 @@ const GerenciarIsolamentosModal = ({ isOpen, onClose, pacientes, infeccoes }) =>
 
       await logAction(
         "Gestão de Isolamentos",
-        `Isolamentos adicionados para ${pacienteSelecionado.nomePaciente}: ${nomeInfeccoes}`
+        `Isolamentos adicionados para ${pacienteSelecionado.nomePaciente}: ${nomeInfeccoes}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/InformacoesReservaModal.jsx
+++ b/src/components/modals/InformacoesReservaModal.jsx
@@ -67,7 +67,8 @@ const InformacoesReservaModal = ({ isOpen, onClose, reserva }) => {
 
       await logAction(
         'Reservas de Leitos',
-        `Observação adicionada para reserva: ${reserva.nomeCompleto}`
+        `Observação adicionada para reserva: ${reserva.nomeCompleto}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/InternacaoManualModal.jsx
+++ b/src/components/modals/InternacaoManualModal.jsx
@@ -50,6 +50,7 @@ import {
 import { ESPECIALIDADES_MEDICAS } from '@/lib/constants';
 import { useToast } from '@/hooks/use-toast';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const internacaoSchema = z.object({
   nomeCompleto: z.string().min(3, 'Informe o nome completo do paciente.'),
@@ -194,6 +195,7 @@ const InternacaoManualModal = ({ isOpen, onClose, leito }) => {
   const [dobPopoverOpen, setDobPopoverOpen] = useState(false);
   const [internacaoPopoverOpen, setInternacaoPopoverOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { currentUser } = useAuth();
 
   const form = useForm({
     resolver: zodResolver(internacaoSchema),
@@ -351,7 +353,8 @@ const InternacaoManualModal = ({ isOpen, onClose, leito }) => {
 
       await logAction(
         'Mapa de Leitos',
-        `Internação Manual - Paciente ${nomePaciente} internado manualmente no leito ${leito.codigoLeito || leito.codigo}.`
+        `Internação Manual - Paciente ${nomePaciente} internado manualmente no leito ${leito.codigoLeito || leito.codigo}.`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/ReservasLeitosModal.jsx
+++ b/src/components/modals/ReservasLeitosModal.jsx
@@ -55,6 +55,7 @@ import {
   deleteField
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 import { ESPECIALIDADES_MEDICAS, ESPECIALIDADES_ONCOLOGIA } from '@/lib/constants';
 
 // Sub-modais
@@ -73,6 +74,7 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
     quartos: [],
     loading: true
   });
+  const { currentUser } = useAuth();
 
   // Estados dos sub-modais
   const [subModals, setSubModals] = useState({
@@ -301,7 +303,8 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
       // Log de auditoria
       await logAction(
         'Reservas de Leitos',
-        `Nova reserva criada: ${novaReserva.nomeCompleto} (${novaReserva.origem})`
+        `Nova reserva criada: ${novaReserva.nomeCompleto} (${novaReserva.origem})`,
+        currentUser
       );
 
       toast({
@@ -787,7 +790,8 @@ const ReservaCard = ({ reserva, onOpenSubModal, leitos }) => {
 
       await logAction(
         'Reservas de Leitos',
-        `Pedido cancelado: ${reserva.nomeCompleto}`
+        `Pedido cancelado: ${reserva.nomeCompleto}`,
+        currentUser
       );
 
       toast({

--- a/src/components/modals/SelecionarLeitoModal.jsx
+++ b/src/components/modals/SelecionarLeitoModal.jsx
@@ -19,6 +19,7 @@ import {
   arrayUnion
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
+import { useAuth } from '@/contexts/AuthContext';
 
 const calcularIdade = (dataNascimento) => {
   if (!dataNascimento) return 0;
@@ -223,6 +224,7 @@ const getLeitosCompatíveis = (paciente, todosOsDados, modo = 'enfermaria') => {
 };
 
 const SelecionarLeitoModal = ({ isOpen, onClose, reserva, dadosHospital }) => {
+  const { currentUser } = useAuth();
   const { toast } = useToast();
 
   const {
@@ -386,7 +388,8 @@ const SelecionarLeitoModal = ({ isOpen, onClose, reserva, dadosHospital }) => {
 
       await logAction(
         'Reservas de Leitos',
-        `Leito ${leito.codigoLeito} reservado para: ${reserva.nomeCompleto}`
+        `Leito ${leito.codigoLeito} reservado para: ${reserva.nomeCompleto}`,
+        currentUser
       );
 
       toast({

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -149,7 +149,7 @@ export const AuthProvider = ({ children }) => {
   const logout = async () => {
     try {
       if (currentUser) {
-        await logAction('Sistema', `Usuário deslogado: ${currentUser.nomeCompleto}`);
+        await logAction('Sistema', `Usuário deslogado: ${currentUser.nomeCompleto}`, currentUser);
       }
       await signOut(auth);
       setCurrentUser(null);
@@ -190,7 +190,7 @@ export const AuthProvider = ({ children }) => {
       });
 
       // Log de auditoria
-      await logAction('Sistema', `Login realizado: ${currentUser.nomeCompleto} (${currentUser.emailInstitucional})`);
+      await logAction('Sistema', `Login realizado: ${currentUser.nomeCompleto} (${currentUser.emailInstitucional})`, currentUser);
       
     } catch (error) {
       console.error('Erro ao registrar auditoria de login:', error);

--- a/src/lib/auditoria.js
+++ b/src/lib/auditoria.js
@@ -4,19 +4,21 @@ import { getAuditoriaCollection } from '@/lib/firebase';
 
 /**
  * Registra uma ação de auditoria no Firestore
- * @param {string} pagina - Nome da página onde ocorreu a ação (ex: "Gerenciamento de Leitos", "Mapa de Leitos")
- * @param {string} mensagemAcao - Descrição legível da ação realizada
+ * @param {string} action - Nome da ação ou contexto (ex: "Gerenciamento de Leitos", "Mapa de Leitos")
+ * @param {any} details - Informações adicionais sobre a ação realizada
+ * @param {object} user - Usuário autenticado responsável pela ação
  */
-export async function logAction(pagina, mensagemAcao) {
+export const logAction = async (action, details, user) => {
   try {
     await addDoc(getAuditoriaCollection(), {
       timestamp: serverTimestamp(),
-      usuario: 'Usuário do Sistema',
-      pagina,
-      acao: mensagemAcao,
+      action,
+      details,
+      userId: user?.uid || 'sistema',
+      userName: user?.nomeCompleto || 'Sistema',
     });
   } catch (err) {
     // Não bloquear o fluxo da aplicação por erro de auditoria
     console.error('Falha ao registrar auditoria:', err);
   }
-}
+};

--- a/src/lib/historicoOcupacoes.js
+++ b/src/lib/historicoOcupacoes.js
@@ -27,8 +27,9 @@ export async function registrarHistoricoOcupacao(paciente, leito, motivoSaida) {
     await addDoc(getHistoricoOcupacoesCollection(), historicoData);
     
     await logAction(
-      'Sistema BI', 
-      `Histórico de ocupação registrado: ${paciente.nomePaciente} (${motivoSaida})`
+      'Sistema BI',
+      `Histórico de ocupação registrado: ${paciente.nomePaciente} (${motivoSaida})`,
+      null
     );
   } catch (error) {
     console.error('Erro ao registrar histórico de ocupação:', error);


### PR DESCRIPTION
## Summary
- update the shared `logAction` helper to accept the acting user and persist their identifier in Firestore
- inject `useAuth` across service components and modals so every audit log includes the authenticated user context
- ensure authentication flows log login/logout events with the associated user metadata

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d70dd954e48322a8f51618c41814e4