### PR TITLE
Add reservations activity tracking to recent activities

### DIFF
--- a/src/components/modals/CancelarReservaExternaModal.jsx
+++ b/src/components/modals/CancelarReservaExternaModal.jsx
@@ -19,7 +19,8 @@ import {
   writeBatch,
   db,
   deleteField,
-  arrayUnion
+  arrayUnion,
+  serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
 import { useAuth } from '@/contexts/AuthContext';
@@ -52,7 +53,13 @@ const CancelarReservaExternaModal = ({ isOpen, onClose, reserva, leito }) => {
       const reservaRef = doc(getReservasExternasCollection(), reserva.id);
       batch.update(reservaRef, {
         leitoReservadoId: deleteField(),
-        status: decisao === 'fila' ? 'Aguardando Leito' : 'Cancelada'
+        leitoCodigo: deleteField(),
+        status: decisao === 'fila' ? 'Aguardando Leito' : 'Cancelada',
+        atualizadoEm: serverTimestamp(),
+        userName: currentUser?.nomeCompleto || 'Usuário',
+        ...(decisao === 'fila'
+          ? { motivoCancelamento: deleteField() }
+          : { motivoCancelamento: 'Cancelamento confirmado pelo usuário' })
       });
 
       if (leitoSelecionadoId) {

--- a/src/components/modals/CancelarReservaModal.jsx
+++ b/src/components/modals/CancelarReservaModal.jsx
@@ -11,9 +11,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { AlertTriangle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { 
-  updateDoc, 
-  doc, 
+import {
+  doc,
   db,
   writeBatch,
   arrayUnion,
@@ -56,7 +55,10 @@ const CancelarReservaModal = ({ isOpen, onClose, reserva }) => {
       const reservaRef = doc(db, 'artifacts/regulafacil/public/data/reservasExternas', reserva.id);
       batch.update(reservaRef, {
         leitoReservadoId: null,
-        observacoes: arrayUnion(observacao)
+        observacoes: arrayUnion(observacao),
+        atualizadoEm: serverTimestamp(),
+        userName: currentUser?.nomeCompleto || 'Sistema',
+        motivoCancelamento: deleteField()
       });
 
       // Liberar o leito se estiver reservado

--- a/src/components/modals/ConfirmarInternacaoModal.jsx
+++ b/src/components/modals/ConfirmarInternacaoModal.jsx
@@ -27,16 +27,15 @@ import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { CalendarIcon, UserCheck, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { 
+import {
   addDoc,
-  updateDoc, 
-  doc, 
+  doc,
   db,
   writeBatch,
   serverTimestamp,
   deleteField
 } from '@/lib/firebase';
-import { getPacientesCollection, getLeitosCollection } from '@/lib/firebase';
+import { getPacientesCollection } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
 import { useAuth } from '@/contexts/AuthContext';
 import { ESPECIALIDADES_MEDICAS } from '@/lib/constants';
@@ -106,6 +105,7 @@ const ConfirmarInternacaoModal = ({ isOpen, onClose, reserva }) => {
     setInternando(true);
     try {
       const batch = writeBatch(db);
+      const timestampAtualizacao = serverTimestamp();
 
       // Criar documento do paciente
       const novoPaciente = {
@@ -140,7 +140,9 @@ const ConfirmarInternacaoModal = ({ isOpen, onClose, reserva }) => {
       batch.update(reservaRef, {
         status: 'Internado',
         pacienteId: pacienteRef.id,
-        dataEfetivacaoInternacao: serverTimestamp()
+        dataEfetivacaoInternacao: timestampAtualizacao,
+        atualizadoEm: timestampAtualizacao,
+        userName: currentUser?.nomeCompleto || 'Usuário'
       });
 
       await batch.commit();

--- a/src/components/modals/InformacoesReservaModal.jsx
+++ b/src/components/modals/InformacoesReservaModal.jsx
@@ -19,7 +19,8 @@ import {
   updateDoc,
   doc,
   db,
-  arrayUnion
+  arrayUnion,
+  serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
 import { useAuth } from '@/contexts/AuthContext';
@@ -59,9 +60,11 @@ const InformacoesReservaModal = ({ isOpen, onClose, reserva }) => {
       };
 
       await updateDoc(
-        doc(db, 'artifacts/regulafacil/public/data/reservasExternas', reserva.id), 
+        doc(db, 'artifacts/regulafacil/public/data/reservasExternas', reserva.id),
         {
-          observacoes: arrayUnion(observacao)
+          observacoes: arrayUnion(observacao),
+          atualizadoEm: serverTimestamp(),
+          userName: currentUser?.nomeCompleto || 'Usuário Desconhecido'
         }
       );
 

--- a/src/components/modals/ReservasLeitosModal.jsx
+++ b/src/components/modals/ReservasLeitosModal.jsx
@@ -276,6 +276,7 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
       // Criar documento da reserva
       const reservaData = {
         nomeCompleto: novaReserva.nomeCompleto,
+        pacienteNome: novaReserva.nomeCompleto,
         dataNascimento: novaReserva.dataNascimento,
         sexo: novaReserva.sexo,
         isolamento: novaReserva.isolamento,
@@ -283,7 +284,9 @@ const ReservasLeitosModal = ({ isOpen, onClose }) => {
         status: 'Aguardando Leito',
         leitoReservadoId: null,
         observacoes: [],
-        criadoEm: serverTimestamp()
+        criadoEm: serverTimestamp(),
+        atualizadoEm: serverTimestamp(),
+        userName: currentUser?.nomeCompleto || 'Usuário'
       };
 
       // Adicionar campos específicos por origem
@@ -784,7 +787,11 @@ const ReservaCard = ({ reserva, onOpenSubModal, leitos }) => {
         doc(db, 'artifacts/regulafacil/public/data/reservasExternas', reserva.id),
         {
           status: 'Cancelada',
-          leitoReservadoId: deleteField()
+          leitoReservadoId: deleteField(),
+          leitoCodigo: deleteField(),
+          atualizadoEm: serverTimestamp(),
+          userName: currentUser?.nomeCompleto || 'Usuário',
+          motivoCancelamento: 'Cancelamento do pedido de reserva'
         }
       );
 

--- a/src/components/modals/SelecionarLeitoModal.jsx
+++ b/src/components/modals/SelecionarLeitoModal.jsx
@@ -12,11 +12,11 @@ import { Card, CardContent } from '@/components/ui/card';
 import { BedDouble, MapPin } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import {
-  updateDoc,
   doc,
   db,
   writeBatch,
-  arrayUnion
+  arrayUnion,
+  serverTimestamp
 } from '@/lib/firebase';
 import { logAction } from '@/lib/auditoria';
 import { useAuth } from '@/contexts/AuthContext';
@@ -354,7 +354,10 @@ const SelecionarLeitoModal = ({ isOpen, onClose, reserva, dadosHospital }) => {
       const reservaRef = doc(db, 'artifacts/regulafacil/public/data/reservasExternas', reserva.id);
       batch.update(reservaRef, {
         leitoReservadoId: leito.id,
-        status: 'Reservado'
+        leitoCodigo: leito.codigoLeito || null,
+        status: 'Reservado',
+        atualizadoEm: serverTimestamp(),
+        userName: currentUser?.nomeCompleto || 'Usuário'
       });
 
       // Atualizar leito com informações da reserva


### PR DESCRIPTION
## Summary
- add a real-time listener for external bed reservations and merge them into the recent activities data set with a dedicated "Reservas" tab
- format reservation lifecycle messages alongside existing audit logs and show reservation metadata such as assigned beds and cancellation reasons
- persist the acting user and update timestamps on reservation create and update flows to power the activity feed

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d71554e34c8322adfc533be5b398f5