### PR TITLE
Fix emergency isolation incompatibility detection

### DIFF
--- a/src/components/GestaoIsolamentosPage.jsx
+++ b/src/components/GestaoIsolamentosPage.jsx
@@ -334,6 +334,14 @@ const GestaoIsolamentosPage = () => {
 
       if (pacientesComIsolamento.length > 0 && pacientesSemIsolamento.length > 0) {
         pacientesComIsolamento.forEach((item) => registrarRisco(item));
+      } else if (pacientesComIsolamento.length > 1) {
+        const assinaturas = new Set(
+          pacientesComIsolamento.map((item) => normalizarIsolamentos(item.paciente))
+        );
+
+        if (assinaturas.size > 1) {
+          pacientesComIsolamento.forEach((item) => registrarRisco(item));
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- extend emergency sector risk detection to flag patients when incompatible isolations coexist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d725ffe2e8832292668ff4bc158380