### PR TITLE
Fix bed compatibility reference and ensure final regulation status

### DIFF
--- a/src/components/RegulacoesEmAndamentoPanel.jsx
+++ b/src/components/RegulacoesEmAndamentoPanel.jsx
@@ -435,6 +435,7 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
       batch.set(
         historicoRef,
         {
+          status: 'Concluída',
           dataConclusao: serverTimestamp(),
           userNameConclusao: nomeUsuario,
           statusFinal: 'Concluída',
@@ -522,6 +523,7 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
       batch.set(
         historicoRef,
         {
+          status: 'Cancelada',
           dataCancelamento: serverTimestamp(),
           userNameCancelamento: nomeUsuario,
           statusFinal: 'Cancelada',

--- a/src/lib/compatibilidadeLeitos.js
+++ b/src/lib/compatibilidadeLeitos.js
@@ -290,7 +290,7 @@ export const getLeitosCompativeis = (
     }
 
     if (leito.quartoId) {
-      const leitosDoQuarto = obterLeitosDoQuarto(leito, { quartosPorId, leitosPorId, todosLeitos });
+      const leitosDoQuarto = obterLeitosDoQuarto(leito, { quartosPorId, leitosPorId, todosOsLeitos });
       const ocupantes = leitosDoQuarto
         .filter((outroLeito) => outroLeito.id !== leito.id)
         .map((outroLeito) => pacientesPorLeito.get(outroLeito.id))


### PR DESCRIPTION
## Summary
- fix the bed compatibility helper call by passing the correct todosOsLeitos reference
- persist the final status in historical regulation records when concluding or cancelling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7649c3b2083229c22c802391bc1c7