### PR TITLE
Normalize patient data before bed compatibility checks

### DIFF
--- a/src/lib/compatibilidadeLeitos.js
+++ b/src/lib/compatibilidadeLeitos.js
@@ -84,27 +84,36 @@ const extrairInformacoesIsolamento = (isolamento) => {
 
   if (typeof isolamento === 'object') {
     const sigla =
-      isolamento.siglaInfeccao ||
       isolamento.sigla ||
+      isolamento.siglaInfeccao ||
       isolamento.codigo ||
       isolamento.tipo ||
       isolamento.nome ||
       '';
 
     const nome =
-      isolamento.nomeInfeccao ||
       isolamento.nome ||
+      isolamento.nomeInfeccao ||
       isolamento.descricao ||
       sigla ||
       'Isolamento';
 
+    const infeccaoRef = isolamento.infeccaoId ?? isolamento.infecaoId;
+    const infeccaoId =
+      typeof infeccaoRef === 'string'
+        ? infeccaoRef
+        : typeof infeccaoRef === 'object' && infeccaoRef
+          ? infeccaoRef.id || infeccaoRef?.path?.split?.('/')?.pop?.()
+          : '';
+
     const identificador =
-      isolamento.infeccaoId ??
-      isolamento.infecaoId ??
-      isolamento.id ??
-      isolamento.codigo ??
-      sigla ??
-      nome ??
+      sigla ||
+      isolamento.siglaInfeccao ||
+      isolamento.codigo ||
+      isolamento.tipo ||
+      isolamento.id ||
+      infeccaoId ||
+      nome ||
       '';
 
     const chaveBase = normalizarTexto(identificador || sigla || nome);
@@ -156,11 +165,12 @@ const normalizarRestricaoIsolamentos = (lista) => {
 
     if (typeof item === 'object') {
       const chave = normalizarTexto(
+        item.sigla ??
+        item.siglaInfeccao ??
         item.infeccaoId ??
         item.infecaoId ??
         item.id ??
         item.codigo ??
-        item.sigla ??
         item.nome ??
         item.tipo ??
         ''


### PR DESCRIPTION
## Summary
- normalize patients coming from Firestore by converting references to ids, enforcing sex values, and resolving isolation metadata before rendering the regulation modal
- cache infection documents and enrich isolation details so getLeitosCompativeis receives consistent siglas and names
- adjust isolation compatibility helpers to rely on sigla-based keys and honor normalized restriction data

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' required by eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c4538da08322bdac5201cdd1b2ea