### PR TITLE
Add additional isolation debugging logs

### DIFF
--- a/src/components/RegulacaoLeitosPage.jsx
+++ b/src/components/RegulacaoLeitosPage.jsx
@@ -104,20 +104,29 @@ const RegulacaoLeitosPage = () => {
       const unsubPacientes = onSnapshot(getPacientesCollection(), (snapshot) => {
         (async () => {
           const pacientesData = await Promise.all(
-            snapshot.docs.map(doc =>
-              processarPaciente(
-                {
-                  id: doc.id,
-                  ...doc.data()
-                },
-                infeccoesMap
-              )
-            )
+            snapshot.docs.map(async (doc) => {
+              const dadosBrutos = {
+                id: doc.id,
+                ...doc.data()
+              };
+
+              console.log('[RegulacaoLeitosPage] Paciente bruto:', {
+                id: dadosBrutos.id,
+                nome: dadosBrutos?.nomePaciente,
+                sexo: dadosBrutos?.sexo,
+                leitoId: dadosBrutos?.leitoId,
+                isolamentos: dadosBrutos?.isolamentos
+              });
+
+              return processarPaciente(dadosBrutos, infeccoesMap);
+            })
           );
 
           if (!ativo) return;
 
-          setPacientes(pacientesData.filter(Boolean));
+          const pacientesFiltrados = pacientesData.filter(Boolean);
+          console.log('[RegulacaoLeitosPage] Pacientes carregados:', pacientesFiltrados);
+          setPacientes(pacientesFiltrados);
         })();
       });
       unsubscribes.push(unsubPacientes);

--- a/src/lib/compatibilidadeLeitos.js
+++ b/src/lib/compatibilidadeLeitos.js
@@ -136,9 +136,12 @@ const extrairIsolamentosAtivosInterno = (lista) => {
   const detalhes = [];
   const chavesSet = new Set();
 
+  console.log('[Compatibilidade] Lista de isolamentos recebida:', lista);
+
   valores.forEach((item) => {
     if (!isIsolamentoAtivo(item)) return;
     const info = extrairInformacoesIsolamento(item);
+    console.log('[Compatibilidade] Isolamento extraído:', info);
     if (!info || !info.chave) return;
     if (chavesSet.has(info.chave)) return;
     chavesSet.add(info.chave);
@@ -256,6 +259,12 @@ export const getLeitosCompativeis = (
 
   const sexoPaciente = normalizarSexo(paciente?.sexo);
   const { chave: chaveIsolamentoPaciente } = extrairIsolamentosAtivosInterno(paciente?.isolamentos);
+  console.log('[Compatibilidade] Iniciando cálculo para paciente:', paciente?.nomePaciente, {
+    sexo: paciente?.sexo,
+    leitoId: paciente?.leitoId,
+    isolamentos: paciente?.isolamentos,
+  });
+  console.log('[Compatibilidade] Isolamento paciente:', chaveIsolamentoPaciente);
   const idadePaciente = calcularIdade(paciente?.dataNascimento);
   const setorOrigemNormalizado = normalizarTexto(paciente?.setorOrigem);
 
@@ -306,6 +315,13 @@ export const getLeitosCompativeis = (
         .map((outroLeito) => pacientesPorLeito.get(outroLeito.id))
         .filter(Boolean);
 
+      console.log('[Compatibilidade] Avaliando leito:', leito.codigoLeito, 'Quarto:', leito.quartoId);
+      console.log('[Compatibilidade] Ocupantes do quarto:', ocupantes.map((o) => ({
+        nome: o?.nomePaciente,
+        sexo: o?.sexo,
+        isolamentos: o?.isolamentos,
+      })));
+
       if (ocupantes.length > 0) {
         const sexos = new Set(
           ocupantes
@@ -314,13 +330,27 @@ export const getLeitosCompativeis = (
         );
 
         if (sexos.size > 1) {
+          console.log('[Compatibilidade] REJEITADO por sexo inconsistente entre ocupantes:', {
+            sexosOcupantes: Array.from(sexos),
+          });
           return;
         }
 
         if (sexos.size === 1) {
           const [sexoQuarto] = Array.from(sexos);
-          if (sexoQuarto && sexoPaciente && sexoQuarto !== sexoPaciente) return;
-          if (sexoQuarto && !sexoPaciente) return;
+          if (sexoQuarto && sexoPaciente && sexoQuarto !== sexoPaciente) {
+            console.log('[Compatibilidade] REJEITADO por sexo:', {
+              sexoPaciente,
+              sexoQuarto,
+            });
+            return;
+          }
+          if (sexoQuarto && !sexoPaciente) {
+            console.log('[Compatibilidade] REJEITADO por sexo indefinido do paciente.', {
+              sexoQuarto,
+            });
+            return;
+          }
         }
 
         const chavesOcupantes = new Set();
@@ -335,18 +365,32 @@ export const getLeitosCompativeis = (
         }
 
         if (chavesOcupantes.size > 1) {
+          console.log('[Compatibilidade] REJEITADO por múltiplos isolamentos entre ocupantes:', {
+            chavesOcupantes: Array.from(chavesOcupantes),
+          });
           return;
         }
 
         const [chaveOcupantes] = Array.from(chavesOcupantes);
+        console.log('[Compatibilidade] Isolamento paciente:', chaveIsolamentoPaciente, 'Isolamento ocupantes:', chaveOcupantes);
         if (chaveOcupantes) {
-          if (chaveOcupantes !== chaveIsolamentoPaciente) return;
+          if (chaveOcupantes !== chaveIsolamentoPaciente) {
+            console.log('[Compatibilidade] REJEITADO por isolamento incompatível:', {
+              chavePaciente: chaveIsolamentoPaciente,
+              chaveOcupantes,
+            });
+            return;
+          }
         } else if (chaveIsolamentoPaciente) {
+          console.log('[Compatibilidade] REJEITADO por isolamento do paciente sem correspondência no quarto:', {
+            chavePaciente: chaveIsolamentoPaciente,
+          });
           return;
         }
       }
     }
 
+    console.log('[Compatibilidade] ACEITO leito:', leito.codigoLeito, 'para paciente:', paciente?.nomePaciente);
     leitosCompativeis.push(leito);
   });
 

--- a/src/lib/pacienteUtils.js
+++ b/src/lib/pacienteUtils.js
@@ -29,10 +29,17 @@ export const normalizarEstruturaPaciente = (paciente) => {
 
   pacienteNormalizado.sexo = normalizarSexo(pacienteNormalizado.sexo);
 
+  console.log(
+    '[PacienteUtils] Isolamentos brutos do paciente',
+    pacienteNormalizado?.nomePaciente,
+    pacienteNormalizado?.isolamentos
+  );
+
   if (Array.isArray(pacienteNormalizado.isolamentos)) {
     pacienteNormalizado.isolamentos = pacienteNormalizado.isolamentos
       .filter(Boolean)
       .map((isolamentoOriginal) => {
+        console.log('[PacienteUtils] Processando isolamento:', isolamentoOriginal);
         if (!isolamentoOriginal || typeof isolamentoOriginal !== 'object') {
           return isolamentoOriginal;
         }
@@ -64,6 +71,8 @@ export const normalizarEstruturaPaciente = (paciente) => {
   } else {
     pacienteNormalizado.isolamentos = [];
   }
+
+  console.log('[PacienteUtils] Paciente normalizado:', pacienteNormalizado);
 
   return pacienteNormalizado;
 };
@@ -115,6 +124,13 @@ export const processarPaciente = async (paciente, infeccoesMap = new Map()) => {
     pacienteNormalizado.isolamentos,
     infeccoesMap
   );
+
+  console.log('[PacienteUtils] Paciente enriquecido:', {
+    nome: pacienteNormalizado?.nomePaciente,
+    sexo: pacienteNormalizado?.sexo,
+    leitoId: pacienteNormalizado?.leitoId,
+    isolamentos: isolamentosDetalhados,
+  });
 
   return { ...pacienteNormalizado, isolamentos: isolamentosDetalhados };
 };


### PR DESCRIPTION
## Summary
- add detailed logging during patient normalization and enrichment to trace Firestore data
- instrument the regulation page snapshot to show raw and processed patient datasets
- add compatibility decision logs covering occupant details, isolation keys, and rejection reasons
- extend isolation extraction logging to inspect raw lists and processed isolation info

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d03733008322857f233121925df4