### PR TITLE
Centralize leito cohort logic in hospital data pipeline

### DIFF
--- a/src/components/modals/RegularPacienteModal.jsx
+++ b/src/components/modals/RegularPacienteModal.jsx
@@ -61,17 +61,20 @@ const RegularPacienteModal = ({
 
   const pacienteEnriquecido = useMemo(() => {
     if (!hospitalData || !paciente) return null;
-    return hospitalData.pacientes.find(p => p.id === paciente.id) || paciente;
+    return hospitalData.pacientes.find(p => p.id === paciente.id) || null;
   }, [hospitalData, paciente]);
 
   const relatorio = useMemo(() => {
-    if (!hospitalData || !pacienteEnriquecido) return null;
+    if (!hospitalData || !paciente) return null;
+    const pacienteAtualizado = hospitalData.pacientes.find(p => p.id === paciente.id);
+    if (!pacienteAtualizado) return null;
+
     const pacienteComIdade = {
-      ...pacienteEnriquecido,
-      idade: calcularIdade(pacienteEnriquecido.dataNascimento),
+      ...pacienteAtualizado,
+      idade: calcularIdade(pacienteAtualizado.dataNascimento),
     };
     return getRelatorioCompatibilidade(pacienteComIdade, hospitalData, modo);
-  }, [hospitalData, pacienteEnriquecido, modo]);
+  }, [hospitalData, paciente, modo]);
 
   // Preserva o fluxo de confirmação direta
   useEffect(() => {
@@ -142,6 +145,7 @@ const RegularPacienteModal = ({
     }
 
     const { porSexo, porPCP, porIsolamento } = relatorio.regras;
+    const pacienteParaResumo = pacienteEnriquecido || paciente;
     const isolamentosAtivos = pacienteEnriquecido
       ? [...getChavesIsolamentoAtivo(pacienteEnriquecido)].join(', ') || 'Nenhum'
       : 'Desconhecido';
@@ -153,8 +157,8 @@ const RegularPacienteModal = ({
             <CardTitle className="text-base">Perfil do Paciente</CardTitle>
           </CardHeader>
           <CardContent className="text-sm space-y-2">
-            <p><strong>Nome:</strong> {pacienteEnriquecido?.nomePaciente || paciente?.nomePaciente}</p>
-            <p><strong>Sexo:</strong> {pacienteEnriquecido?.sexo || 'N/I'}</p>
+            <p><strong>Nome:</strong> {pacienteParaResumo?.nomePaciente || paciente?.nomePaciente}</p>
+            <p><strong>Sexo:</strong> {pacienteEnriquecido?.sexo || paciente?.sexo || 'N/I'}</p>
             <p><strong>Isolamentos:</strong> {isolamentosAtivos}</p>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- build the hospital data pipeline to assemble setor > quarto > leito hierarchy and annotate cohort restrictions on vacant beds
- simplify the compatibility engine to consume precomputed cohort data when evaluating available beds
- ensure the regulation modal reads the enriched patient from the pipeline before generating diagnostics

## Testing
- npm run lint *(fails: missing @eslint/js dependency due to unresolved peer dependency conflict during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d9029651dc832285f98538f19ce891