### PR TITLE
Add isolation diagnostics modal and refine bed compatibility logic

### DIFF
--- a/src/components/MapaLeitosPanel.jsx
+++ b/src/components/MapaLeitosPanel.jsx
@@ -32,7 +32,8 @@ import {
   LogOut,
   Search,
   Filter,
-  X
+  X,
+  Wrench
 } from 'lucide-react';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -62,6 +63,7 @@ import AltaNoLeitoModal from './modals/AltaNoLeitoModal';
 import CancelarReservaExternaModal from './modals/CancelarReservaExternaModal';
 import ConfirmarInternacaoExternaModal from './modals/ConfirmarInternacaoExternaModal';
 import InternacaoManualModal from './modals/InternacaoManualModal';
+import DiagnosticoIsolamentosModal from './modals/DiagnosticoIsolamentosModal';
 
 // Color mapping for sector types
 const getSectorTypeColor = (tipoSetor) => {
@@ -777,6 +779,7 @@ const MapaLeitosPanel = () => {
   const [modalCancelarReservaExterna, setModalCancelarReservaExterna] = useState({ open: false, reserva: null, leito: null });
   const [modalConfirmarInternacaoExterna, setModalConfirmarInternacaoExterna] = useState({ open: false, reserva: null, leito: null });
   const [modalInternacaoManual, setModalInternacaoManual] = useState({ open: false, leito: null });
+  const [diagIsoModalOpen, setDiagIsoModalOpen] = useState(false);
 
   const construirContextoReservaExterna = (leitoAtual) => {
     const dadosReserva = leitoAtual?.reservaExterna || {};
@@ -1830,6 +1833,22 @@ const MapaLeitosPanel = () => {
 
   return (
     <div className="space-y-4">
+      <Card className="bg-white border border-gray-200 rounded-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Wrench className="h-4 w-4 text-primary" />
+            Caixa de Ferramentas
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            <Button variant="outline" onClick={() => setDiagIsoModalOpen(true)}>
+              Diagnóstico de Isolamentos
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Painel de Filtros */}
       <div className="bg-white border border-gray-200 rounded-lg p-4">
         {/* Busca Rápida */}
@@ -2296,6 +2315,12 @@ const MapaLeitosPanel = () => {
         isOpen={modalInternacaoManual.open}
         onClose={() => setModalInternacaoManual({ open: false, leito: null })}
         leito={modalInternacaoManual.leito}
+      />
+
+      <DiagnosticoIsolamentosModal
+        isOpen={diagIsoModalOpen}
+        onClose={() => setDiagIsoModalOpen(false)}
+        pacientes={pacientes}
       />
     </div>
   );

--- a/src/components/modals/DiagnosticoIsolamentosModal.jsx
+++ b/src/components/modals/DiagnosticoIsolamentosModal.jsx
@@ -1,0 +1,50 @@
+// src/components/modals/DiagnosticoIsolamentosModal.jsx
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+
+const DiagnosticoIsolamentosModal = ({ isOpen, onClose, pacientes }) => {
+  const pacientesComIsolamento = pacientes.filter(p => p.isolamentos && p.isolamentos.length > 0);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Diagnóstico de Isolamentos (Pacientes Ativos)</DialogTitle>
+        </DialogHeader>
+        <div className="py-4">
+          <p className="mb-4 text-sm text-muted-foreground">
+            Esta é uma lista de todos os pacientes atualmente internados que possuem isolamentos ativos, com base nos dados processados pelo pipeline.
+          </p>
+          <ScrollArea className="h-96 border rounded-lg p-3">
+            {pacientesComIsolamento.length > 0 ? (
+              <div className="space-y-4">
+                {pacientesComIsolamento.map(paciente => (
+                  <div key={paciente.id} className="p-3 bg-muted/50 rounded-md">
+                    <p className="font-semibold">{paciente.nomePaciente}</p>
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      {paciente.isolamentos.map((iso, index) => (
+                        <Badge key={index} variant="destructive">
+                          {iso.siglaInfeccao || iso.sigla || 'N/A'} ({iso.status})
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-center text-muted-foreground">Nenhum paciente com isolamento ativo encontrado.</p>
+            )}
+          </ScrollArea>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>Fechar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DiagnosticoIsolamentosModal;

--- a/src/lib/hospitalData.js
+++ b/src/lib/hospitalData.js
@@ -26,28 +26,23 @@ const fetchCollection = async (getCollection) => {
  * @returns {Object} O objeto do paciente processado.
  */
 const processarPaciente = (paciente, infeccoesMap) => {
-  // 1. Normalização Estrutural Básica
   const pacienteProcessado = { ...paciente };
 
-  // Garante que 'sexo' seja estritamente 'M' ou 'F'
   const sexoUpper = (paciente.sexo || '').trim().toUpperCase();
   pacienteProcessado.sexo = (sexoUpper === 'M' || sexoUpper === 'F') ? sexoUpper : null;
 
-  // Garante que 'leitoId' seja uma string, se existir
   if (paciente.leitoId && typeof paciente.leitoId === 'object') {
     pacienteProcessado.leitoId = paciente.leitoId.id || null;
   }
 
-  // 2. Enriquecimento dos Isolamentos
   if (Array.isArray(paciente.isolamentos)) {
     pacienteProcessado.isolamentos = paciente.isolamentos
       .map(iso => {
-        if (!iso || !iso.infeccaoId) return null; // Ignora isolamentos malformados
+        if (!iso || !iso.infeccaoId) return null;
 
         const infeccaoId = (typeof iso.infeccaoId === 'object') ? iso.infeccaoId.id : iso.infeccaoId;
         const dadosInfeccao = infeccoesMap.get(infeccaoId);
 
-        // Se não encontrarmos a infecção no mapa, não podemos enriquecer, mas mantemos o que temos.
         if (!dadosInfeccao) {
           return {
             ...iso,
@@ -55,35 +50,24 @@ const processarPaciente = (paciente, infeccoesMap) => {
           };
         }
 
-        // Retorna o isolamento original mesclado com os dados da infecção
         return {
           ...iso,
-          ...dadosInfeccao, // Injeta siglaInfeccao, nomeInfeccao, etc.
+          ...dadosInfeccao,
           statusConsideradoAtivo: ['CONFIRMADO', 'SUSPEITO'].includes((iso.status || '').toUpperCase()),
         };
       })
-      .filter(Boolean); // Remove quaisquer isolamentos nulos
+      .filter(Boolean);
   } else {
-    pacienteProcessado.isolamentos = []; // Garante que seja sempre um array
+    pacienteProcessado.isolamentos = [];
   }
 
   return pacienteProcessado;
 };
 
-/**
- * Função principal do pipeline. Agora ela enriquece E estrutura os dados do hospital
- * em uma hierarquia de Setores > Quartos > Leitos, aplicando as regras de coorte.
- */
 export const getHospitalData = async () => {
   console.log('[HospitalData] Iniciando busca, enriquecimento e ESTRUTURAÇÃO de dados...');
 
-  const [
-    pacientesCrus,
-    leitos,
-    setores,
-    quartos,
-    infeccoes,
-  ] = await Promise.all([
+  const [pacientesCrus, leitos, setores, quartos, infeccoes] = await Promise.all([
     fetchCollection(getPacientesCollection),
     fetchCollection(getLeitosCollection),
     fetchCollection(getSetoresCollection),
@@ -99,7 +83,6 @@ export const getHospitalData = async () => {
       .map(p => [p.leitoId, p]),
   );
 
-  // Vincula pacientes já processados aos leitos correspondentes
   const leitosComPacientes = leitos.map(leito => ({
     ...leito,
     paciente: pacientesPorLeitoId.get(leito.id) || null,
@@ -127,80 +110,76 @@ export const getHospitalData = async () => {
       }, {});
       quartosDoSetor = Object.values(gruposQuarto);
     } else {
-      const quartosOficiais = quartos.filter(q => q.setorId === setor.id);
-      quartosDoSetor = quartosOficiais.map(quarto => {
-        const idsPermitidos = new Set(quarto.leitosIds || []);
-        const leitosDoQuarto = leitosDoSetor.filter(l => idsPermitidos.has(l.id) || l.quartoId === quarto.id);
-        leitosDoQuarto.forEach(leito => {
-          leito.quartoId = quarto.id;
+      quartosDoSetor = quartos
+        .filter(q => q.setorId === setor.id)
+        .map(quarto => {
+          const idsPermitidos = new Set(quarto.leitosIds || []);
+          const leitosDoQuarto = leitosDoSetor.filter(l => idsPermitidos.has(l.id));
+          leitosDoQuarto.forEach(leito => {
+            leito.quartoId = quarto.id;
+          });
+          return {
+            ...quarto,
+            leitos: leitosDoQuarto,
+          };
         });
-        return {
-          ...quarto,
-          leitos: leitosDoQuarto,
-        };
+    }
+
+    const leitosSemQuarto = leitosDoSetor.filter(leito => !quartosDoSetor.some(quarto => quarto.leitos.includes(leito)));
+    if (leitosSemQuarto.length > 0) {
+      leitosSemQuarto.forEach(leito => {
+        leito.quartoId = null;
+      });
+    }
+
+    const aplicarCoorte = (leitosQuarto) => {
+      const ocupantes = leitosQuarto.map(l => l.paciente).filter(Boolean);
+      if (ocupantes.length === 0) {
+        return null;
+      }
+
+      const sexosOcupantes = new Set(ocupantes.map(o => o.sexo).filter(Boolean));
+      const chavesIsolamento = new Set();
+      ocupantes.forEach(o => {
+        (o.isolamentos || [])
+          .filter(iso => iso.statusConsideradoAtivo)
+          .forEach(iso => {
+            const chave = (iso.siglaInfeccao || iso.sigla || '').toLowerCase();
+            if (chave) {
+              chavesIsolamento.add(chave);
+            }
+          });
       });
 
-      const leitosSemQuarto = leitosDoSetor.filter(leito => !quartosDoSetor.some(quarto => quarto.leitos.includes(leito)));
-      if (leitosSemQuarto.length > 0) {
-        const quartoGenericoId = `quarto-generico-${setor.id}`;
-        leitosSemQuarto.forEach(leito => {
-          leito.quartoId = quartoGenericoId;
-        });
-        quartosDoSetor.push({
-          id: quartoGenericoId,
-          nomeQuarto: 'Quarto Não Definido',
-          setorId: setor.id,
-          leitos: leitosSemQuarto,
-        });
-      }
-    }
-
-    for (const quarto of quartosDoSetor) {
-      const ocupantes = quarto.leitos.map(l => l.paciente).filter(Boolean);
-      let restricao = null;
-
-      if (ocupantes.length > 0) {
-        const sexosOcupantes = new Set(ocupantes.map(o => o.sexo).filter(Boolean));
-        const chavesIsolamento = new Set();
-        ocupantes.forEach(o => {
-          (o.isolamentos || [])
-            .filter(iso => iso.statusConsideradoAtivo)
-            .forEach(iso => {
-              const chave = (iso.siglaInfeccao || iso.sigla || '').toLowerCase();
-              if (chave) {
-                chavesIsolamento.add(chave);
-              }
-            });
-        });
-
-        if (sexosOcupantes.size === 1) {
-          restricao = {
-            sexo: [...sexosOcupantes][0],
-            isolamentos: [...chavesIsolamento],
-          };
-        }
+      if (sexosOcupantes.size === 1) {
+        return {
+          sexo: [...sexosOcupantes][0],
+          isolamentos: [...chavesIsolamento].filter(Boolean),
+        };
       }
 
-      for (const leito of quarto.leitos) {
+      return null;
+    };
+
+    quartosDoSetor.forEach(quarto => {
+      const restricao = aplicarCoorte(quarto.leitos);
+      quarto.leitos.forEach(leito => {
         const status = (leito.status || '').toUpperCase();
-        if ((status === 'VAGO' || status === 'HIGIENIZAÇÃO') && restricao) {
+        if (restricao && (status === 'VAGO' || status === 'HIGIENIZAÇÃO')) {
           leito.restricaoCoorte = restricao;
+        } else {
+          delete leito.restricaoCoorte;
         }
-      }
-    }
+      });
+    });
 
-    return { ...setor, quartos: quartosDoSetor };
+    return { ...setor, quartos: quartosDoSetor, leitosSemQuarto };
   });
 
-  const hospitalData = {
+  console.log('[HospitalData] Pipeline com ESTRUTURA HIERÁRQUICA concluído.');
+  return {
     estrutura: estruturaFinal,
     pacientes: pacientesProcessados,
     leitos: leitosComPacientes,
-    setores,
-    quartos,
-    infeccoes,
   };
-
-  console.log('[HospitalData] Pipeline com ESTRUTURA HIERÁRQUICA concluído.', hospitalData);
-  return hospitalData;
 };


### PR DESCRIPTION
## Summary
- add a diagnostics modal for active patient isolations and expose it from the Mapa de Leitos toolbox
- refactor the hospital data pipeline to build a hierarchical structure with cohort restrictions attached to beds
- update the bed compatibility engine to consume the preprocessed structure and enforce setor type filtering

## Testing
- npm run build *(fails: vite command missing before dependencies are installed)*
- npm install *(fails: peer dependency conflict between date-fns@4 and react-day-picker@8)*

------
https://chatgpt.com/codex/tasks/task_e_68d90a00eb808322bf09b1c70949cff6