### PR TITLE
Exclude blocked beds from assistive occupancy calculations

### DIFF
--- a/src/components/dashboards/MapaLeitosDashboard.jsx
+++ b/src/components/dashboards/MapaLeitosDashboard.jsx
@@ -297,8 +297,9 @@ const MapaLeitosDashboard = () => {
       const setor = setoresPorId.get(leito.setorId);
       const tipoNorm = normalizarTexto(setor?.tipoSetor);
       const status = normalizarTexto(leito.status || leito.statusLeito);
+      const statusAssistencialAtivo = status === 'ocupado' || status === 'vago' || status === 'higienizacao';
 
-      if (setoresAssistenciais.has(tipoNorm)) {
+      if (setoresAssistenciais.has(tipoNorm) && statusAssistencialAtivo) {
         totalAssistenciais += 1;
         if (status === 'ocupado') {
           ocupadosAssistenciais += 1;


### PR DESCRIPTION
## Summary
- exclude blocked beds from assistive occupancy totals so the occupancy rate ignores non-operational beds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99c5e951083229d33e8cdc02e4d48