### PR TITLE
fix: filter duplicate lookup by active patients

### DIFF
--- a/src/components/modals/ConfirmarInternacaoExternaModal.jsx
+++ b/src/components/modals/ConfirmarInternacaoExternaModal.jsx
@@ -345,55 +345,61 @@ const ConfirmarInternacaoExternaModal = ({ isOpen, onClose, reserva, leito }) =>
       const duplicados = await getDocs(pacientesQuery);
 
       if (!duplicados.empty) {
-        const pacienteExistenteDoc = duplicados.docs[0];
-        const pacienteExistente = pacienteExistenteDoc.data();
+        const pacienteAtivoDoc = duplicados.docs.find((docSnapshot) => {
+          const status = docSnapshot.data()?.status;
+          return !status || status === 'Ativo';
+        });
 
-        let setorPaciente = 'Setor não informado';
-        let codigoLeitoPaciente = 'Não informado';
+        if (pacienteAtivoDoc) {
+          const pacienteExistente = pacienteAtivoDoc.data();
 
-        if (pacienteExistente?.leitoId) {
-          const leitoRefExistente = doc(getLeitosCollection(), pacienteExistente.leitoId);
-          const leitoSnapshot = await getDoc(leitoRefExistente);
-          if (leitoSnapshot.exists()) {
-            const leitoData = leitoSnapshot.data();
-            codigoLeitoPaciente = leitoData?.codigoLeito || codigoLeitoPaciente;
-            setorPaciente =
-              leitoData?.nomeSetor ||
-              leitoData?.setorNome ||
-              setorPaciente;
+          let setorPaciente = 'Setor não informado';
+          let codigoLeitoPaciente = 'Não informado';
 
-            if ((!setorPaciente || setorPaciente === 'Setor não informado') && leitoData?.setorId) {
-              const setorRef = doc(getSetoresCollection(), leitoData.setorId);
-              const setorSnapshot = await getDoc(setorRef);
-              if (setorSnapshot.exists()) {
-                const setorData = setorSnapshot.data();
-                setorPaciente =
-                  setorData?.nomeSetor ||
-                  setorData?.siglaSetor ||
-                  setorPaciente;
+          if (pacienteExistente?.leitoId) {
+            const leitoRefExistente = doc(getLeitosCollection(), pacienteExistente.leitoId);
+            const leitoSnapshot = await getDoc(leitoRefExistente);
+            if (leitoSnapshot.exists()) {
+              const leitoData = leitoSnapshot.data();
+              codigoLeitoPaciente = leitoData?.codigoLeito || codigoLeitoPaciente;
+              setorPaciente =
+                leitoData?.nomeSetor ||
+                leitoData?.setorNome ||
+                setorPaciente;
+
+              if ((!setorPaciente || setorPaciente === 'Setor não informado') && leitoData?.setorId) {
+                const setorRef = doc(getSetoresCollection(), leitoData.setorId);
+                const setorSnapshot = await getDoc(setorRef);
+                if (setorSnapshot.exists()) {
+                  const setorData = setorSnapshot.data();
+                  setorPaciente =
+                    setorData?.nomeSetor ||
+                    setorData?.siglaSetor ||
+                    setorPaciente;
+                }
               }
             }
           }
-        }
-
-        if ((setorPaciente === 'Setor não informado' || !setorPaciente) && pacienteExistente?.setorId) {
-          const setorRef = doc(getSetoresCollection(), pacienteExistente.setorId);
-          const setorSnapshot = await getDoc(setorRef);
-          if (setorSnapshot.exists()) {
-            const setorData = setorSnapshot.data();
-            setorPaciente =
-              setorData?.nomeSetor ||
-              setorData?.siglaSetor ||
-              setorPaciente;
           }
-        }
 
-        toast({
-          title: 'Paciente já internado',
-          description: `Paciente já internado. ${nomePaciente} consta no sistema. Localização: ${setorPaciente || 'Setor não informado'}, Leito: ${codigoLeitoPaciente || 'Não informado'}. Utilize a função 'Mover Paciente' para ajustes.`,
-          variant: 'destructive',
-        });
-        return;
+          if ((setorPaciente === 'Setor não informado' || !setorPaciente) && pacienteExistente?.setorId) {
+            const setorRef = doc(getSetoresCollection(), pacienteExistente.setorId);
+            const setorSnapshot = await getDoc(setorRef);
+            if (setorSnapshot.exists()) {
+              const setorData = setorSnapshot.data();
+              setorPaciente =
+                setorData?.nomeSetor ||
+                setorData?.siglaSetor ||
+                setorPaciente;
+            }
+          }
+          toast({
+            title: 'Paciente já internado',
+            description: `Paciente já internado. ${nomePaciente} consta no sistema. Localização: ${setorPaciente || 'Setor não informado'}, Leito: ${codigoLeitoPaciente || 'Não informado'}. Utilize a função 'Mover Paciente' para ajustes.`,
+            variant: 'destructive',
+          });
+          return;
+        }
       }
 
       let setorId = leito?.setorId || null;


### PR DESCRIPTION
## Summary
- refatora o ConfirmarInternacaoExternaModal para coletar e validar dados do paciente, evitar duplicidades e registrar a internação com atualização do leito
- adiciona react-imask e aplica campos de data mascarados no fluxo de novas reservas externas
- exige confirmação ao reservar um leito e restringe opções a oncologia quando aplicável
- ajusta a verificação de duplicidade para considerar apenas internações ativas antes de bloquear o fluxo

## Testing
- `npm run lint` *(falha devido a avisos/erros já existentes no projeto relacionados a arquivos UI e tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9dde77a483228685a6b531423df9