### PR TITLE
Ordena feed de regulações por atualização mais recente

### DIFF
--- a/src/components/RegulaFacilAuth.jsx
+++ b/src/components/RegulaFacilAuth.jsx
@@ -748,8 +748,14 @@ const HomePage = ({ onNavigate, currentUser }) => {
       };
     });
 
-    return limitarLogs(logs);
-  }, [historicoRegulacoes, construirMensagemHistoricoRegulacao, limitarLogs, normalizarSemAcento]);
+    return limitarLogs(ordenarPorDataDesc(logs));
+  }, [
+    historicoRegulacoes,
+    construirMensagemHistoricoRegulacao,
+    limitarLogs,
+    normalizarSemAcento,
+    ordenarPorDataDesc,
+  ]);
 
   const isolamentoLogs = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- ordena os registros de historicoRegulacoes por data do último evento antes de limitar o feed
- inclui o utilitário de ordenação por data como dependência do cálculo das entradas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbabaee7883228d46896e392d922c