### PR TITLE
Implement bed reassignment flow for ongoing regulations

### DIFF
--- a/src/components/RegulacoesEmAndamentoPanel.jsx
+++ b/src/components/RegulacoesEmAndamentoPanel.jsx
@@ -209,14 +209,70 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
 
   // Função para obter informações do leito
   const obterInfoLeito = (leitoId) => {
-    const leito = leitos.find(l => l.id === leitoId);
-    if (!leito) return { codigo: 'N/A', siglaSetor: 'N/A' };
-    
-    const setor = setores.find(s => s.id === leito.setorId);
+    if (!leitoId) {
+      return {
+        id: null,
+        codigo: 'N/A',
+        codigoLeito: 'N/A',
+        siglaSetor: 'N/A',
+        nomeSetor: 'Setor não informado',
+        setorId: null,
+        status: 'Indefinido',
+      };
+    }
+
+    const leito = leitos.find((l) => l.id === leitoId);
+    if (!leito) {
+      return {
+        id: leitoId,
+        codigo: 'N/A',
+        codigoLeito: 'N/A',
+        siglaSetor: 'N/A',
+        nomeSetor: 'Setor não informado',
+        setorId: null,
+        status: 'Indisponível',
+      };
+    }
+
+    const setor = setores.find((s) => s.id === leito.setorId);
+
     return {
+      id: leito.id,
       codigo: leito.codigoLeito || 'N/A',
-      siglaSetor: setor?.siglaSetor || 'N/A'
+      codigoLeito: leito.codigoLeito || 'N/A',
+      siglaSetor: setor?.siglaSetor || leito.siglaSetor || 'N/A',
+      nomeSetor: setor?.nomeSetor || leito.nomeSetor || 'Setor não informado',
+      setorId: leito.setorId || setor?.id || null,
+      status: leito.status || 'Indefinido',
+      dadosCompletos: leito,
     };
+  };
+
+  const montarContextoAlteracao = (paciente) => {
+    if (!paciente?.regulacaoAtiva) {
+      return null;
+    }
+
+    return {
+      paciente,
+      leitoOrigem: obterInfoLeito(paciente.regulacaoAtiva.leitoOrigemId),
+      leitoDestino: obterInfoLeito(paciente.regulacaoAtiva.leitoDestinoId),
+    };
+  };
+
+  const abrirModalAlterar = (paciente) => {
+    const contexto = montarContextoAlteracao(paciente);
+
+    if (!contexto) {
+      toast({
+        title: 'Não foi possível abrir a alteração',
+        description: 'Os dados da regulação ativa não foram encontrados para este paciente.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setModalAlterar({ isOpen: true, regulacao: contexto });
   };
 
   // Função para copiar texto personalizado
@@ -627,7 +683,7 @@ const RegulacoesEmAndamentoPanel = ({ filtros, sortConfig }) => {
                   variant="ghost"
                   size="icon"
                   className="h-8 w-8 shrink-0 text-blue-600/90 hover:text-blue-600"
-                  onClick={() => setModalAlterar({ isOpen: true, regulacao: paciente })}
+                  onClick={() => abrirModalAlterar(paciente)}
                   aria-label="Alterar regulação"
                 >
                   <Pencil className="h-4 w-4" />

--- a/src/components/modals/AlterarRegulacaoModal.jsx
+++ b/src/components/modals/AlterarRegulacaoModal.jsx
@@ -3,234 +3,522 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card } from "@/components/ui/card";
-import { toast } from "@/hooks/use-toast";
-import { 
-  onSnapshot,
-  getLeitosCollection,
-  getQuartosCollection,
-  getSetoresCollection,
-  getPacientesCollection,
-  writeBatch,
-  doc,
+import { useToast } from "@/hooks/use-toast";
+import {
   arrayUnion,
   deleteField,
+  doc,
+  getHistoricoRegulacoesCollection,
+  getLeitosCollection,
+  getPacientesCollection,
   serverTimestamp,
+  writeBatch,
   db,
-  getHistoricoRegulacoesCollection
 } from '@/lib/firebase';
-import LeitoSelectionStep from './steps/LeitoSelectionStep';
 import { logAction } from '@/lib/auditoria';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDadosHospitalares } from '@/hooks/useDadosHospitalares';
+import LeitoSelectionStep from './steps/LeitoSelectionStep';
+import { Loader2 } from "lucide-react";
+
+const TITULOS = {
+  selecionar: 'Selecionar novo leito',
+  justificativa: 'Justificativa da alteração',
+  confirmacao: 'Confirmar alteração da regulação',
+};
 
 const AlterarRegulacaoModal = ({ isOpen, onClose, regulacao }) => {
-  const paciente = regulacao;
-  const [dados, setDados] = useState({ leitos: [], quartos: [], setores: [], pacientes: [], loading: true });
-  const [step, setStep] = useState('selecao');
-  const [novoLeito, setNovoLeito] = useState(null);
-  const [justificativa, setJustificativa] = useState('');
+  const { paciente: pacienteBase, leitoOrigem: leitoOrigemBase, leitoDestino: leitoDestinoBase } = regulacao || {};
+  const { estrutura, pacientesEnriquecidos, leitos = [], setores = [], loading } = useDadosHospitalares();
+  const { toast } = useToast();
   const { currentUser } = useAuth();
 
+  const [step, setStep] = useState('selecionar');
+  const [novoLeito, setNovoLeito] = useState(null);
+  const [justificativa, setJustificativa] = useState('');
+  const [processando, setProcessando] = useState(false);
+
   useEffect(() => {
-    if (!isOpen || !paciente) return;
-    let unsubs = [];
+    if (!isOpen) {
+      setStep('selecionar');
+      setNovoLeito(null);
+      setJustificativa('');
+      setProcessando(false);
+    }
+  }, [isOpen]);
 
-    const load = async () => {
-      setDados((p) => ({ ...p, loading: true }));
-      try {
-        const u1 = onSnapshot(getLeitosCollection(), (snap) => {
-          setDados((p) => ({ ...p, leitos: snap.docs.map(d => ({ id: d.id, ...d.data() })) }));
-        });
-        const u2 = onSnapshot(getQuartosCollection(), (snap) => {
-          setDados((p) => ({ ...p, quartos: snap.docs.map(d => ({ id: d.id, ...d.data() })) }));
-        });
-        const u3 = onSnapshot(getSetoresCollection(), (snap) => {
-          setDados((p) => ({ ...p, setores: snap.docs.map(d => ({ id: d.id, ...d.data() })) }));
-        });
-        const u4 = onSnapshot(getPacientesCollection(), (snap) => {
-          setDados((p) => ({ ...p, pacientes: snap.docs.map(d => ({ id: d.id, ...d.data() })), loading: false }));
-        });
-        unsubs = [u1, u2, u3, u4];
-      } catch (e) {
-        console.error('Erro ao carregar dados:', e);
-        setDados((p) => ({ ...p, loading: false }));
-      }
-    };
-    load();
-    return () => unsubs.forEach(u => u && u());
-  }, [isOpen, paciente]);
+  const pacienteAtual = useMemo(() => {
+    if (!pacienteBase) return null;
+    return pacientesEnriquecidos.find((p) => p.id === pacienteBase.id) || pacienteBase;
+  }, [pacientesEnriquecidos, pacienteBase]);
 
-  const modo = useMemo(() => (paciente?.pedidoUTI ? 'uti' : 'enfermaria'), [paciente]);
-
-  const obterInfoLeito = (leitoId) => {
-    const leito = dados.leitos.find(l => l.id === leitoId);
-    if (!leito) return { codigo: 'N/A', siglaSetor: 'N/A' };
-    const setor = dados.setores.find(s => s.id === leito.setorId);
-    return { codigo: leito.codigoLeito || 'N/A', siglaSetor: setor?.siglaSetor || 'N/A' };
-  };
+  const regulacaoAtiva = pacienteAtual?.regulacaoAtiva || null;
 
   const origemInfo = useMemo(() => {
-    if (!paciente?.regulacaoAtiva) return null;
-    return obterInfoLeito(paciente.regulacaoAtiva.leitoOrigemId);
-  }, [paciente, dados.leitos, dados.setores]);
+    if (!regulacaoAtiva?.leitoOrigemId && !leitoOrigemBase) return null;
+    const id = regulacaoAtiva?.leitoOrigemId || leitoOrigemBase?.id || null;
+    if (!id) return null;
+
+    const leitoDoc = leitos.find((l) => l.id === id) || leitoOrigemBase?.dadosCompletos || null;
+    if (!leitoDoc) {
+      if (!leitoOrigemBase) return null;
+      return {
+        id: leitoOrigemBase.id ?? null,
+        codigo: leitoOrigemBase.codigo || leitoOrigemBase.codigoLeito || 'N/A',
+        codigoLeito: leitoOrigemBase.codigoLeito || leitoOrigemBase.codigo || 'N/A',
+        siglaSetor: leitoOrigemBase.siglaSetor || 'N/A',
+        nomeSetor: leitoOrigemBase.nomeSetor || 'Setor não informado',
+        setorId: leitoOrigemBase.setorId ?? null,
+        status: leitoOrigemBase.status || 'Indefinido',
+      };
+    }
+
+    const setorDoc = setores.find((s) => s.id === leitoDoc.setorId);
+    return {
+      id: leitoDoc.id,
+      codigo: leitoDoc.codigoLeito || leitoOrigemBase?.codigo || leitoOrigemBase?.codigoLeito || 'N/A',
+      codigoLeito: leitoDoc.codigoLeito || leitoOrigemBase?.codigoLeito || leitoOrigemBase?.codigo || 'N/A',
+      siglaSetor: setorDoc?.siglaSetor || leitoOrigemBase?.siglaSetor || 'N/A',
+      nomeSetor: setorDoc?.nomeSetor || leitoOrigemBase?.nomeSetor || 'Setor não informado',
+      setorId: leitoDoc.setorId,
+      status: leitoDoc.status || leitoOrigemBase?.status || 'Indefinido',
+    };
+  }, [regulacaoAtiva, leitos, setores, leitoOrigemBase]);
 
   const destinoAtualInfo = useMemo(() => {
-    if (!paciente?.regulacaoAtiva) return null;
-    return obterInfoLeito(paciente.regulacaoAtiva.leitoDestinoId);
-  }, [paciente, dados.leitos, dados.setores]);
+    if (!regulacaoAtiva?.leitoDestinoId && !leitoDestinoBase) return null;
+    const id = regulacaoAtiva?.leitoDestinoId || leitoDestinoBase?.id || null;
+    if (!id) return null;
 
-  const mensagemPreview = useMemo(() => {
-    if (!paciente || !origemInfo || !destinoAtualInfo || !novoLeito) return '';
-    const novoSetor = dados.setores.find(s => s.id === novoLeito.setorId);
-    const novoDestino = `${novoSetor?.siglaSetor || 'N/A'} - ${novoLeito.codigoLeito}`;
-    return `*REGULAÇÃO ALTERADA*\n\n*Paciente:* _${paciente.nomePaciente}_\n*Origem:* _${origemInfo.siglaSetor} - ${origemInfo.codigo}_\n*Destino Anterior:* _${destinoAtualInfo.siglaSetor} - ${destinoAtualInfo.codigo}_\n*Novo Destino:* _${novoDestino}_\n*Motivo:* _${justificativa || '[preencher]'}_\n\n_${new Date().toLocaleString()}_`;
-  }, [paciente, origemInfo, destinoAtualInfo, novoLeito, justificativa, dados.setores]);
+    const leitoDoc = leitos.find((l) => l.id === id) || leitoDestinoBase?.dadosCompletos || null;
+    if (!leitoDoc) {
+      if (!leitoDestinoBase) return null;
+      return {
+        id: leitoDestinoBase.id ?? null,
+        codigo: leitoDestinoBase.codigo || leitoDestinoBase.codigoLeito || 'N/A',
+        codigoLeito: leitoDestinoBase.codigoLeito || leitoDestinoBase.codigo || 'N/A',
+        siglaSetor: leitoDestinoBase.siglaSetor || 'N/A',
+        nomeSetor: leitoDestinoBase.nomeSetor || 'Setor não informado',
+        setorId: leitoDestinoBase.setorId ?? null,
+        status: leitoDestinoBase.status || 'Indefinido',
+      };
+    }
 
-  const onSelectLeito = (leito) => {
-    setNovoLeito(leito);
-    setStep('confirmacao');
-  };
+    const setorDoc = setores.find((s) => s.id === leitoDoc.setorId);
+    return {
+      id: leitoDoc.id,
+      codigo: leitoDoc.codigoLeito || leitoDestinoBase?.codigo || leitoDestinoBase?.codigoLeito || 'N/A',
+      codigoLeito: leitoDoc.codigoLeito || leitoDestinoBase?.codigoLeito || leitoDestinoBase?.codigo || 'N/A',
+      siglaSetor: setorDoc?.siglaSetor || leitoDestinoBase?.siglaSetor || 'N/A',
+      nomeSetor: setorDoc?.nomeSetor || leitoDestinoBase?.nomeSetor || 'Setor não informado',
+      setorId: leitoDoc.setorId,
+      status: leitoDoc.status || leitoDestinoBase?.status || 'Indefinido',
+    };
+  }, [regulacaoAtiva, leitos, setores, leitoDestinoBase]);
 
-  const handleVoltar = () => {
-    setStep('selecao');
-    setNovoLeito(null);
-  };
+  const novoLeitoInfo = useMemo(() => {
+    if (!novoLeito) return null;
+    const leitoDoc = leitos.find((l) => l.id === novoLeito.id) || null;
+    const setorDoc = leitoDoc
+      ? setores.find((s) => s.id === leitoDoc.setorId)
+      : setores.find((s) => s.id === novoLeito.setorId);
+
+    return {
+      id: leitoDoc?.id || novoLeito.id,
+      codigo: leitoDoc?.codigoLeito || novoLeito.codigoLeito || novoLeito.codigo || 'N/A',
+      codigoLeito: leitoDoc?.codigoLeito || novoLeito.codigoLeito || novoLeito.codigo || 'N/A',
+      siglaSetor: setorDoc?.siglaSetor || novoLeito.siglaSetor || 'N/A',
+      nomeSetor: setorDoc?.nomeSetor || novoLeito.nomeSetor || 'Setor não informado',
+      setorId: leitoDoc?.setorId || novoLeito.setorId || setorDoc?.id || null,
+      status: leitoDoc?.status || novoLeito.status || 'Indefinido',
+      quartoId: leitoDoc?.quartoId || novoLeito.quartoId || null,
+    };
+  }, [novoLeito, leitos, setores]);
+
+  const modo = useMemo(() => (pacienteAtual?.pedidoUTI ? 'uti' : 'enfermaria'), [pacienteAtual]);
+
+  const justificativaNormalizada = justificativa.trim();
+
+  const resumoConfirmacao = useMemo(() => {
+    if (!pacienteAtual || !origemInfo || !destinoAtualInfo || !novoLeitoInfo || !justificativaNormalizada) {
+      return null;
+    }
+
+    return {
+      pacienteNome: pacienteAtual.nomePaciente,
+      origemDescricao: `${origemInfo.siglaSetor || origemInfo.nomeSetor} - ${origemInfo.codigo}`,
+      destinoAnteriorDescricao: `${destinoAtualInfo.siglaSetor || destinoAtualInfo.nomeSetor} - ${destinoAtualInfo.codigo}`,
+      novoDestinoDescricao: `${novoLeitoInfo.siglaSetor || novoLeitoInfo.nomeSetor} - ${novoLeitoInfo.codigo}`,
+      justificativa: justificativaNormalizada,
+    };
+  }, [pacienteAtual, origemInfo, destinoAtualInfo, novoLeitoInfo, justificativaNormalizada]);
+
+  const excludedLeitoIds = useMemo(() => {
+    const ids = [];
+    if (regulacaoAtiva?.leitoDestinoId) ids.push(regulacaoAtiva.leitoDestinoId);
+    if (regulacaoAtiva?.leitoOrigemId) ids.push(regulacaoAtiva.leitoOrigemId);
+    return ids;
+  }, [regulacaoAtiva]);
+
+  const hospitalData = useMemo(
+    () => ({ estrutura, leitos, setores, pacientesEnriquecidos }),
+    [estrutura, leitos, setores, pacientesEnriquecidos]
+  );
 
   const fechar = () => {
-    setStep('selecao');
+    if (processando) return;
+    setStep('selecionar');
     setNovoLeito(null);
     setJustificativa('');
+    setProcessando(false);
     onClose?.();
   };
 
+  const handleSelecionarLeito = (leito) => {
+    setNovoLeito(leito);
+    setStep('justificativa');
+  };
+
+  const handleVoltarSelecao = () => {
+    if (processando) return;
+    setStep('selecionar');
+    setNovoLeito(null);
+  };
+
+  const handleAvancarConfirmacao = () => {
+    if (!justificativaNormalizada) return;
+    setStep('confirmacao');
+  };
+
   const confirmarAlteracao = async () => {
-    if (!paciente || !paciente.regulacaoAtiva || !novoLeito) return;
+    if (!pacienteAtual || !regulacaoAtiva || !novoLeitoInfo || !destinoAtualInfo || !origemInfo) {
+      toast({
+        title: 'Não foi possível alterar a regulação',
+        description: 'Dados insuficientes para concluir a alteração.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setProcessando(true);
+
     try {
       const batch = writeBatch(db);
       const ts = serverTimestamp();
       const nomeUsuario = currentUser?.nomeCompleto || 'Usuário do Sistema';
-      const justificativaTexto = justificativa.trim();
+      const justificativaTexto = justificativaNormalizada;
 
-      const pacienteRef = doc(getPacientesCollection(), paciente.id);
-      const origemId = paciente.regulacaoAtiva.leitoOrigemId;
-      const destinoAnteriorId = paciente.regulacaoAtiva.leitoDestinoId;
-      const historicoRef = doc(getHistoricoRegulacoesCollection(), paciente.id);
+      const pacienteRef = doc(getPacientesCollection(), pacienteAtual.id);
+      const origemId = regulacaoAtiva.leitoOrigemId;
+      const destinoAnteriorId = regulacaoAtiva.leitoDestinoId;
+      const historicoRef = doc(getHistoricoRegulacoesCollection(), pacienteAtual.id);
 
-      // 1) Atualiza paciente.regulacaoAtiva
+      const regulacaoAtualizada = {
+        ...regulacaoAtiva,
+        leitoDestinoId: novoLeitoInfo.id,
+        setorDestinoId: novoLeitoInfo.setorId ?? regulacaoAtiva.setorDestinoId ?? null,
+        leitoDestinoCodigo: novoLeitoInfo.codigoLeito,
+        leitoDestinoSetorNome: novoLeitoInfo.nomeSetor,
+        ultimaAlteracaoEm: ts,
+        ultimaJustificativa: justificativaTexto,
+        userUltimaAlteracao: nomeUsuario,
+      };
+
       batch.update(pacienteRef, {
-        regulacaoAtiva: {
-          ...paciente.regulacaoAtiva,
-          leitoDestinoId: novoLeito.id,
-          setorDestinoId: novoLeito.setorId,
-          iniciadoEm: ts,
-        }
+        regulacaoAtiva: regulacaoAtualizada,
       });
 
-      // 2) Limpa destino anterior
-      const destinoAnteriorRef = doc(getLeitosCollection(), destinoAnteriorId);
-      batch.update(destinoAnteriorRef, {
-        regulacaoEmAndamento: deleteField(),
-        status: 'Vago',
-        historico: arrayUnion({ status: 'Vago', timestamp: new Date() })
-      });
+      if (destinoAnteriorId) {
+        const destinoAnteriorRef = doc(getLeitosCollection(), destinoAnteriorId);
+        batch.update(destinoAnteriorRef, {
+          regulacaoEmAndamento: deleteField(),
+          status: 'Vago',
+          historico: arrayUnion({
+            status: 'Vago',
+            timestamp: ts,
+            origem: 'alteracao-regulacao',
+            pacienteId: pacienteAtual.id,
+          }),
+        });
+      }
 
-      // 3) Marca novo destino
-      const novoDestinoRef = doc(getLeitosCollection(), novoLeito.id);
+      const novoDestinoRef = doc(getLeitosCollection(), novoLeitoInfo.id);
       batch.update(novoDestinoRef, {
         regulacaoEmAndamento: {
           tipo: 'DESTINO',
-          pacienteId: paciente.id,
-          pacienteNome: paciente.nomePaciente,
+          pacienteId: pacienteAtual.id,
+          pacienteNome: pacienteAtual.nomePaciente,
           leitoParceiroId: origemId,
-          leitoParceiroCodigo: obterInfoLeito(origemId).codigo,
-          iniciadoEm: ts
-        }
+          leitoParceiroCodigo: origemInfo.codigoLeito || origemInfo.codigo,
+          leitoParceiroSetorNome: origemInfo.siglaSetor || origemInfo.nomeSetor || null,
+          iniciadoEm: regulacaoAtiva?.iniciadoEm || ts,
+          atualizadoEm: ts,
+        },
+        status: 'Reservado',
+        historico: arrayUnion({
+          status: 'Reservado',
+          timestamp: ts,
+          origem: 'alteracao-regulacao',
+          pacienteId: pacienteAtual.id,
+        }),
       });
 
-      // 4) Ajusta leito de origem para apontar para novo destino (integridade)
-      const origemRef = doc(getLeitosCollection(), origemId);
-      batch.update(origemRef, {
-        regulacaoEmAndamento: {
-          ...dados.leitos.find(l => l.id === origemId)?.regulacaoEmAndamento,
-          tipo: 'ORIGEM',
-          pacienteId: paciente.id,
-          pacienteNome: paciente.nomePaciente,
-          leitoParceiroId: novoLeito.id,
-          leitoParceiroCodigo: novoLeito.codigoLeito,
-          iniciadoEm: paciente.regulacaoAtiva?.iniciadoEm || ts
-        }
-      });
+      if (origemId) {
+        const origemRef = doc(getLeitosCollection(), origemId);
+        const leitoOrigemDoc = leitos.find((l) => l.id === origemId);
+        const regulacaoOrigemAtual = leitoOrigemDoc?.regulacaoEmAndamento || {};
+
+        batch.update(origemRef, {
+          regulacaoEmAndamento: {
+            ...regulacaoOrigemAtual,
+            tipo: 'ORIGEM',
+            pacienteId: pacienteAtual.id,
+            pacienteNome: pacienteAtual.nomePaciente,
+            leitoParceiroId: novoLeitoInfo.id,
+            leitoParceiroCodigo: novoLeitoInfo.codigoLeito,
+            leitoParceiroSetorNome: novoLeitoInfo.siglaSetor || novoLeitoInfo.nomeSetor || null,
+            iniciadoEm: regulacaoOrigemAtual?.iniciadoEm || regulacaoAtiva?.iniciadoEm || ts,
+            atualizadoEm: ts,
+          },
+        });
+      }
 
       batch.set(
         historicoRef,
         {
-          leitoDestinoId: novoLeito.id,
-          setorDestinoId: novoLeito.setorId,
+          status: 'Em andamento',
           ultimaAlteracaoEm: ts,
           userNameUltimaAlteracao: nomeUsuario,
           justificativaUltimaAlteracao: justificativaTexto,
           alteracoes: arrayUnion({
-            data: new Date(),
+            tipo: 'alteracao',
+            timestamp: ts,
+            realizadoPor: nomeUsuario,
             justificativa: justificativaTexto,
-            novoLeitoDestinoId: novoLeito.id,
-            novoSetorDestinoId: novoLeito.setorId,
-            userName: nomeUsuario
-          })
+            deLeitoId: destinoAnteriorId || null,
+            deLeitoCodigo: destinoAtualInfo.codigoLeito || destinoAtualInfo.codigo,
+            deSetorSigla: destinoAtualInfo.siglaSetor || null,
+            deSetorNome: destinoAtualInfo.nomeSetor || null,
+            paraLeitoId: novoLeitoInfo.id,
+            paraLeitoCodigo: novoLeitoInfo.codigoLeito,
+            paraSetorSigla: novoLeitoInfo.siglaSetor || null,
+            paraSetorNome: novoLeitoInfo.nomeSetor || null,
+          }),
         },
         { merge: true }
       );
 
       await batch.commit();
 
-      const usuario = nomeUsuario;
-      const destAnteriorStr = `${destinoAtualInfo?.siglaSetor} - ${destinoAtualInfo?.codigo}`;
-      const novoDestinoStr = `${dados.setores.find(s => s.id === novoLeito.setorId)?.siglaSetor || 'N/A'} - ${novoLeito.codigoLeito}`;
-      await logAction('Regulação de Leitos', `Regulação do paciente '${paciente.nomePaciente}' foi ALTERADA por ${usuario} do leito '${destAnteriorStr}' para '${novoDestinoStr}'. Motivo: '${justificativaTexto}'.`, currentUser);
+      await logAction(
+        'Regulação de Leitos',
+        `Regulação do paciente '${pacienteAtual.nomePaciente}' atualizada de ${destinoAtualInfo.siglaSetor || destinoAtualInfo.nomeSetor} - ${destinoAtualInfo.codigo} para ${novoLeitoInfo.siglaSetor || novoLeitoInfo.nomeSetor} - ${novoLeitoInfo.codigoLeito}. Motivo: '${justificativaTexto}'.`,
+        currentUser
+      );
 
-      toast({ title: 'Regulação alterada', description: 'A alteração foi aplicada com sucesso.' });
+      toast({
+        title: 'Regulação alterada',
+        description: 'O novo leito foi reservado e a regulação atualizada com sucesso.',
+      });
+
       fechar();
-    } catch (e) {
-      console.error('Erro ao alterar regulação:', e);
-      toast({ title: 'Erro', description: 'Falha ao alterar a regulação.', variant: 'destructive' });
+    } catch (error) {
+      console.error('Erro ao alterar regulação:', error);
+      toast({
+        title: 'Erro ao alterar regulação',
+        description: 'Não foi possível concluir a alteração. Tente novamente em instantes.',
+        variant: 'destructive',
+      });
+    } finally {
+      setProcessando(false);
     }
   };
 
-  if (!paciente) return null;
+  const renderResumoAtual = () => {
+    if (!pacienteAtual || !origemInfo || !destinoAtualInfo) {
+      return null;
+    }
+
+    return (
+      <Card className="bg-muted/40 p-4 text-sm">
+        <div className="flex flex-col gap-2">
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Paciente</p>
+            <p className="font-semibold text-foreground">{pacienteAtual.nomePaciente}</p>
+          </div>
+          <div className="grid gap-2 md:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Setor e leito de origem</p>
+              <p className="font-medium text-foreground">
+                {origemInfo.siglaSetor || origemInfo.nomeSetor} - {origemInfo.codigo}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Reserva atual</p>
+              <p className="font-medium text-foreground">
+                {destinoAtualInfo.siglaSetor || destinoAtualInfo.nomeSetor} - {destinoAtualInfo.codigo}
+              </p>
+            </div>
+          </div>
+        </div>
+      </Card>
+    );
+  };
+
+  const renderJustificativaStep = () => (
+    <div className="space-y-4">
+      {renderResumoAtual()}
+
+      {novoLeitoInfo && (
+        <Card className="p-4 text-sm">
+          <p className="text-xs uppercase text-muted-foreground">Novo leito selecionado</p>
+          <p className="font-medium text-foreground">
+            {novoLeitoInfo.siglaSetor || novoLeitoInfo.nomeSetor} - {novoLeitoInfo.codigo}
+          </p>
+        </Card>
+      )}
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Justificativa da alteração</label>
+        <Textarea
+          value={justificativa}
+          onChange={(event) => setJustificativa(event.target.value)}
+          placeholder="Descreva o motivo da alteração da reserva"
+          className="min-h-[120px]"
+          maxLength={500}
+          disabled={processando}
+        />
+        <p className="text-xs text-muted-foreground">
+          O campo é obrigatório. Informe de forma objetiva a motivação da mudança de leito.
+        </p>
+      </div>
+
+      <div className="flex justify-between gap-2 pt-4 border-t">
+        <Button variant="ghost" onClick={handleVoltarSelecao} disabled={processando}>
+          Voltar à seleção
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={fechar} disabled={processando}>
+            Cancelar
+          </Button>
+          <Button onClick={handleAvancarConfirmacao} disabled={!justificativaNormalizada || processando}>
+            Avançar para confirmação
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderConfirmacaoStep = () => (
+    <div className="space-y-4">
+      {resumoConfirmacao && (
+        <Card className="space-y-3 p-4 text-sm">
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Paciente</p>
+            <p className="font-semibold text-foreground">{resumoConfirmacao.pacienteNome}</p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Origem</p>
+              <p className="font-medium text-foreground">{resumoConfirmacao.origemDescricao}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-muted-foreground">Reserva anterior</p>
+              <p className="font-medium text-foreground">{resumoConfirmacao.destinoAnteriorDescricao}</p>
+            </div>
+            <div className="md:col-span-2">
+              <p className="text-xs uppercase text-muted-foreground">Novo leito reservado</p>
+              <p className="font-medium text-foreground">{resumoConfirmacao.novoDestinoDescricao}</p>
+            </div>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Justificativa</p>
+            <p className="whitespace-pre-wrap text-foreground">{resumoConfirmacao.justificativa}</p>
+          </div>
+        </Card>
+      )}
+
+      <div className="flex justify-between gap-2 pt-4 border-t">
+        <Button variant="ghost" onClick={() => setStep('justificativa')} disabled={processando}>
+          Revisar justificativa
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={fechar} disabled={processando}>
+            Cancelar
+          </Button>
+          <Button onClick={confirmarAlteracao} disabled={!resumoConfirmacao || processando}>
+            {processando ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Salvando...
+              </>
+            ) : (
+              'Confirmar alteração'
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderSelecaoStep = () => (
+    <div className="space-y-4">
+      {renderResumoAtual()}
+      <LeitoSelectionStep
+        paciente={pacienteBase}
+        pacienteEnriquecido={pacienteAtual}
+        hospitalData={hospitalData}
+        modo={modo}
+        excludedLeitoIds={excludedLeitoIds}
+        loading={loading}
+        onLeitoSelect={handleSelecionarLeito}
+      />
+      <div className="flex justify-end gap-2 pt-4 border-t">
+        <Button variant="outline" onClick={fechar}>
+          Fechar
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderConteudo = () => {
+    if (!pacienteAtual || !regulacaoAtiva || !origemInfo || !destinoAtualInfo) {
+      return (
+        <div className="space-y-4">
+          <Card className="p-4 text-sm">
+            <p className="font-medium text-destructive">
+              Não foi possível carregar todos os dados necessários para alterar esta regulação.
+            </p>
+            <p className="text-muted-foreground">
+              Verifique se a regulação ainda está ativa e tente novamente.
+            </p>
+          </Card>
+          <div className="flex justify-end">
+            <Button onClick={fechar}>Fechar</Button>
+          </div>
+        </div>
+      );
+    }
+
+    if (step === 'selecionar') return renderSelecaoStep();
+    if (step === 'justificativa') return renderJustificativaStep();
+    return renderConfirmacaoStep();
+  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) fechar(); }}>
-      <DialogContent className="max-w-3xl" onInteractOutside={(e) => e.preventDefault()} onEscapeKeyDown={(e) => e.preventDefault()}>
+    <Dialog open={isOpen} onOpenChange={(open) => (!open ? fechar() : null)}>
+      <DialogContent
+        className="max-w-3xl"
+        onInteractOutside={(event) => event.preventDefault()}
+        onEscapeKeyDown={(event) => {
+          if (!processando) return;
+          event.preventDefault();
+        }}
+      >
         <DialogHeader>
-          <DialogTitle>{step === 'selecao' ? 'Selecionar novo leito' : 'Confirmar Alteração de Regulação'}</DialogTitle>
+          <DialogTitle>{TITULOS[step] || 'Alterar regulação'}</DialogTitle>
         </DialogHeader>
-
-        {step === 'selecao' ? (
-          <div className="space-y-4">
-            <LeitoSelectionStep dados={dados} paciente={paciente} modo={modo} onLeitoSelect={onSelectLeito} />
-            <div className="flex justify-end gap-2 pt-4 border-t">
-              <Button variant="outline" onClick={fechar}>Cancelar</Button>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <div>
-              <label className="text-sm font-medium mb-2 block">Pré-visualização</label>
-              <Card className="p-4 bg-muted/50">
-                <pre className="text-sm whitespace-pre-wrap font-mono">{mensagemPreview}</pre>
-              </Card>
-            </div>
-            <div>
-              <label className="text-sm font-medium mb-2 block">Justificativa (obrigatória)</label>
-              <Textarea value={justificativa} onChange={(e) => setJustificativa(e.target.value)} placeholder="Descreva o motivo da alteração" className="min-h-[100px]" />
-            </div>
-            <div className="flex justify-between gap-2 pt-4 border-t">
-              <Button variant="ghost" onClick={handleVoltar}>Voltar</Button>
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={fechar}>Cancelar</Button>
-                <Button onClick={confirmarAlteracao} disabled={!justificativa.trim()}>Confirmar Alteração</Button>
-              </div>
-            </div>
-          </div>
-        )}
+        {renderConteudo()}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/modals/steps/LeitoSelectionStep.jsx
+++ b/src/components/modals/steps/LeitoSelectionStep.jsx
@@ -1,21 +1,251 @@
-import React from 'react';
-import { Wrench } from "lucide-react";
+import React, { useMemo, useState } from 'react';
+import { Loader2 } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { encontrarLeitosCompativeis } from '@/lib/compatibilidadeUtils';
 
-const LeitoSelectionStep = ({ paciente }) => {
-  if (!paciente) {
-    return null;
+const formatarStatus = (status) => {
+  if (!status) return 'Sem status';
+  return String(status)
+    .toLowerCase()
+    .split(' ')
+    .map((parte) => parte.charAt(0).toUpperCase() + parte.slice(1))
+    .join(' ');
+};
+
+const LeitoSelectionStep = ({
+  paciente,
+  pacienteEnriquecido,
+  hospitalData = {},
+  modo = 'enfermaria',
+  excludedLeitoIds = [],
+  loading = false,
+  onLeitoSelect,
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const dadosPaciente = pacienteEnriquecido || paciente;
+  const setores = hospitalData?.setores || [];
+  const leitos = hospitalData?.leitos || [];
+  const pacientesHospital = hospitalData?.pacientesEnriquecidos || [];
+
+  const setoresMap = useMemo(
+    () => new Map(setores.map((setor) => [setor.id, setor])),
+    [setores]
+  );
+
+  const pacientesPorLeito = useMemo(
+    () =>
+      new Map(
+        pacientesHospital
+          .filter((p) => p.leitoId)
+          .map((p) => [p.leitoId, p])
+      ),
+    [pacientesHospital]
+  );
+
+  const pacientesPorQuarto = useMemo(() => {
+    const mapa = new Map();
+
+    leitos.forEach((leitoAtual) => {
+      if (!leitoAtual?.quartoId) return;
+      if (!mapa.has(leitoAtual.quartoId)) {
+        mapa.set(leitoAtual.quartoId, []);
+      }
+      const pacienteNoLeito = pacientesPorLeito.get(leitoAtual.id);
+      if (pacienteNoLeito) {
+        mapa.get(leitoAtual.quartoId).push(pacienteNoLeito);
+      }
+    });
+
+    return mapa;
+  }, [leitos, pacientesPorLeito]);
+
+  const leitosCompativeis = useMemo(() => {
+    if (loading || !dadosPaciente) return [];
+
+    const base = encontrarLeitosCompativeis(dadosPaciente, { estrutura: hospitalData?.estrutura || {} }, modo);
+
+    return base
+      .filter((leito) => leito && !excludedLeitoIds.includes(leito.id))
+      .map((leito) => {
+        const setor = setoresMap.get(leito.setorId);
+        return {
+          ...leito,
+          siglaSetor: leito.siglaSetor || setor?.siglaSetor || '',
+          nomeSetor: leito.nomeSetor || setor?.nomeSetor || setor?.nome || 'Setor não informado',
+        };
+      });
+  }, [loading, dadosPaciente, hospitalData?.estrutura, modo, excludedLeitoIds, setoresMap]);
+
+  const gruposLeitos = useMemo(() => {
+    if (!dadosPaciente) return [];
+
+    const termoBusca = searchTerm.trim().toLowerCase();
+    const nomeCompletoPaciente = (dadosPaciente.nomePaciente || '').trim();
+    const primeiroNomePaciente = nomeCompletoPaciente.split(' ')[0] || '';
+    const primeiroNomePacienteNormalizado = primeiroNomePaciente.toLowerCase();
+    const nomeCompletoPacienteNormalizado = nomeCompletoPaciente.toLowerCase();
+
+    const gruposMap = new Map();
+
+    leitosCompativeis.forEach((leito) => {
+      const codigoLeito = String(leito.codigoLeito || leito.codigo || '');
+      if (termoBusca && !codigoLeito.toLowerCase().includes(termoBusca)) {
+        return;
+      }
+
+      let possuiHomonimo = false;
+      if (leito.quartoId && primeiroNomePacienteNormalizado) {
+        const pacientesNoQuarto = pacientesPorQuarto.get(leito.quartoId) || [];
+        possuiHomonimo = pacientesNoQuarto.some((pacienteVizinho) => {
+          if (!pacienteVizinho?.nomePaciente) return false;
+          if (pacienteVizinho.id === dadosPaciente.id) return false;
+
+          const nomeVizinho = pacienteVizinho.nomePaciente.trim();
+          const primeiroNomeVizinho = (nomeVizinho.split(' ')[0] || '').toLowerCase();
+
+          if (!primeiroNomeVizinho) return false;
+          if (primeiroNomeVizinho !== primeiroNomePacienteNormalizado) return false;
+
+          return nomeVizinho.toLowerCase() !== nomeCompletoPacienteNormalizado;
+        });
+      }
+
+      const nomeSetor = leito.nomeSetor || 'Setor não informado';
+      const siglaSetor = leito.siglaSetor || '';
+      const chaveGrupo = `${leito.setorId || 'sem-setor'}-${siglaSetor || 'sem-sigla'}`;
+
+      if (!gruposMap.has(chaveGrupo)) {
+        gruposMap.set(chaveGrupo, {
+          nomeSetor,
+          siglaSetor,
+          leitos: [],
+        });
+      }
+
+      gruposMap.get(chaveGrupo).leitos.push({
+        ...leito,
+        codigoLeito: codigoLeito || 'N/A',
+        statusFormatado: formatarStatus(leito.status),
+        possuiHomonimo,
+      });
+    });
+
+    return Array.from(gruposMap.values())
+      .map((grupo) => ({
+        ...grupo,
+        leitos: grupo.leitos.sort((a, b) =>
+          String(a.codigoLeito || '').localeCompare(String(b.codigoLeito || ''))
+        ),
+      }))
+      .sort((a, b) => (a.nomeSetor || '').localeCompare(b.nomeSetor || ''));
+  }, [leitosCompativeis, searchTerm, dadosPaciente, pacientesPorQuarto]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-10">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
   }
 
+  if (!dadosPaciente) {
+    return (
+      <div className="flex items-center justify-center p-8 text-sm text-muted-foreground">
+        Não foi possível carregar os dados do paciente.
+      </div>
+    );
+  }
+
+  const totalDisponiveis = leitosCompativeis.length;
+
   return (
-    <div className="flex flex-col items-center justify-center space-y-4 py-12 text-center">
-      <Wrench className="h-12 w-12 text-yellow-500" />
-      <h3 className="text-xl font-semibold">Seleção de Leitos em Desenvolvimento</h3>
-      <p className="text-muted-foreground max-w-md">
-        A etapa automática de sugestão e seleção de leitos está temporariamente indisponível
-        enquanto reconstruímos a funcionalidade.
-        <br />
-        Escolha o leito desejado diretamente no mapa e retorne para confirmar a regulação.
-      </p>
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold">{totalDisponiveis} leito(s) compatível(is) disponível(is)</h3>
+        <p className="text-xs text-muted-foreground">
+          Escolha um novo leito para reservar ao paciente. Apenas leitos compatíveis e vagos são exibidos.
+        </p>
+      </div>
+      <Input
+        value={searchTerm}
+        onChange={(event) => setSearchTerm(event.target.value)}
+        placeholder="Buscar leito pelo código"
+      />
+      <ScrollArea className="h-96 rounded-md border">
+        {totalDisponiveis > 0 ? (
+          <div className="p-4 space-y-6">
+            {gruposLeitos.length > 0 ? (
+              gruposLeitos.map((grupo) => {
+                const quantidadeLeitos = grupo.leitos.length;
+                const textoDisponiveis =
+                  quantidadeLeitos === 1 ? '1 leito disponível' : `${quantidadeLeitos} leitos disponíveis`;
+
+                return (
+                  <div key={`${grupo.nomeSetor}-${grupo.siglaSetor}`} className="space-y-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <h4 className="font-semibold">{grupo.nomeSetor}</h4>
+                        <p className="text-xs text-muted-foreground">{textoDisponiveis}</p>
+                      </div>
+                      {grupo.siglaSetor && (
+                        <Badge variant="outline" className="uppercase">
+                          {grupo.siglaSetor}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      {grupo.leitos.map((leito) => (
+                        <button
+                          key={leito.id}
+                          type="button"
+                          className="w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          onClick={() => onLeitoSelect?.(leito)}
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="font-mono text-sm font-semibold">{leito.codigoLeito}</span>
+                              <Badge variant="secondary" className="capitalize">
+                                {leito.statusFormatado}
+                              </Badge>
+                              {leito.possuiHomonimo && (
+                                <Badge variant="destructive">Homônimo no quarto</Badge>
+                              )}
+                            </div>
+                            {leito.tipoLeito && (
+                              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                                {leito.tipoLeito}
+                              </span>
+                            )}
+                          </div>
+                          {leito.restricaoCoorte && (
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Coorte: {leito.restricaoCoorte.sexo ? `Sexo ${leito.restricaoCoorte.sexo}` : 'Restrição ativa'}
+                              {Array.isArray(leito.restricaoCoorte.isolamentos) &&
+                                leito.restricaoCoorte.isolamentos.length > 0 &&
+                                ` · ${leito.restricaoCoorte.isolamentos.join(', ')}`}
+                            </p>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })
+            ) : (
+              <div className="flex items-center justify-center p-6 text-sm text-muted-foreground">
+                Nenhum leito corresponde ao filtro aplicado.
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
+            Nenhum leito compatível está disponível neste momento.
+          </div>
+        )}
+      </ScrollArea>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enrich the ongoing regulations panel with detailed bed context when opening the alteration modal
- rebuild the alter regulation modal into a multi-step flow that selects a new bed, captures justification, and updates Firestore with the change history
- replace the placeholder bed selection step with a reusable selector that lists compatible, available beds

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e542aa22ec832286ef426a1ba828db