### PR TITLE
Refine isolation risk alerts in isolation dashboard

### DIFF
--- a/src/components/dashboards/GestaoIsolamentosDashboard.jsx
+++ b/src/components/dashboards/GestaoIsolamentosDashboard.jsx
@@ -1,34 +1,220 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Shield, Construction } from 'lucide-react';
+import { Badge } from "@/components/ui/badge";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertTriangle, Shield, ShieldCheck } from 'lucide-react';
+import { useDadosHospitalares } from '@/hooks/useDadosHospitalares';
+import { identificarRiscosDeContaminacao } from '@/lib/compatibilidadeUtils';
+
+const isIsolamentoAtivo = (isolamento) => {
+  if (!isolamento) return false;
+  if (typeof isolamento.statusConsideradoAtivo === 'boolean') {
+    return isolamento.statusConsideradoAtivo;
+  }
+  const status = (isolamento.status || '').toLowerCase();
+  return status === 'confirmado' || status === 'suspeito';
+};
+
+const formatarLocalizacao = (setor, quarto, leito) => {
+  const partes = [];
+  const setorNome = setor?.nomeSetor || setor?.nome || setor?.siglaSetor;
+  if (setorNome) partes.push(setorNome);
+  if (quarto?.nomeQuarto) partes.push(quarto.nomeQuarto);
+  if (leito?.codigoLeito) partes.push(`Leito ${leito.codigoLeito}`);
+  return partes.join(' • ') || 'Localização não informada';
+};
+
+const MENSAGENS_RISCO = {
+  setor_aberto: 'Paciente com isolamento ativo em setor aberto (PS).',
+  ausencia_coorte: 'Paciente isolado compartilhando quarto com companheiro sem isolamento ativo.',
+  coorte_incompativel: 'Isolamentos diferentes entre pacientes do mesmo quarto.',
+};
 
 const GestaoIsolamentosDashboard = () => {
+  const {
+    pacientesEnriquecidos,
+    leitos,
+    setores,
+    quartos,
+    loading,
+  } = useDadosHospitalares();
+
+  const leitosPorId = useMemo(() => new Map(leitos.map(leito => [leito.id, leito])), [leitos]);
+  const setoresPorId = useMemo(() => new Map(setores.map(setor => [setor.id, setor])), [setores]);
+  const quartosPorId = useMemo(
+    () => new Map((quartos || []).map(quarto => [quarto.id, quarto])),
+    [quartos],
+  );
+
+  const pacientesIsolamento = useMemo(() => {
+    if (!Array.isArray(pacientesEnriquecidos)) return [];
+
+    return pacientesEnriquecidos
+      .map(paciente => {
+        const leito = paciente.leitoId ? leitosPorId.get(paciente.leitoId) || null : null;
+        const setor = leito?.setorId ? setoresPorId.get(leito.setorId) || null : setoresPorId.get(paciente.setorId) || null;
+        const quarto = leito?.quartoId ? quartosPorId.get(leito.quartoId) || null : null;
+        const isolamentosAtivos = (paciente.isolamentos || []).filter(isIsolamentoAtivo);
+
+        if (!isolamentosAtivos.length) {
+          return null;
+        }
+
+        return {
+          id: paciente.id,
+          nome: paciente.nomePaciente || paciente.nome || 'Paciente sem identificação',
+          leito,
+          setor,
+          quarto,
+          isolamentos: isolamentosAtivos,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR', { sensitivity: 'base' }));
+  }, [pacientesEnriquecidos, leitosPorId, setoresPorId, quartosPorId]);
+
+  const riscosPorPaciente = useMemo(() => {
+    if (!Array.isArray(pacientesEnriquecidos)) return new Map();
+    return identificarRiscosDeContaminacao(pacientesEnriquecidos, leitos, quartos, setores);
+  }, [pacientesEnriquecidos, leitos, quartos, setores]);
+
+  const totalPacientesIsolados = pacientesIsolamento.length;
+  const totalPacientesEmRisco = riscosPorPaciente.size;
+  const percentualRisco = totalPacientesIsolados
+    ? Math.round((totalPacientesEmRisco / totalPacientesIsolados) * 100)
+    : 0;
+
+  const obterDescricaoRisco = (motivo, detalhes = []) => {
+    if (motivo === 'ausencia_coorte' || motivo === 'coorte_incompativel') {
+      const detalheComQuarto = detalhes.find(item => item?.quartoId);
+      if (detalheComQuarto?.quartoId) {
+        const quarto = quartosPorId.get(detalheComQuarto.quartoId);
+        const nomeQuarto = quarto?.nomeQuarto || `Quarto ${detalheComQuarto.quartoId}`;
+        if (motivo === 'ausencia_coorte') {
+          return `${nomeQuarto}: paciente isolado compartilhando o quarto com companheiro sem isolamento ativo.`;
+        }
+        return `${nomeQuarto}: isolamentos diferentes entre pacientes do mesmo quarto.`;
+      }
+    }
+    return MENSAGENS_RISCO[motivo] || 'Risco de contaminação cruzada identificado.';
+  };
+
   return (
-    <div className="flex items-center justify-center h-96">
-      <Card className="max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex justify-center mb-4">
-            <div className="p-4 bg-red-100 rounded-full">
-              <Shield className="h-12 w-12 text-red-600" />
+    <Card className="shadow-sm">
+      <CardHeader>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Shield className="h-5 w-5 text-primary" />
+            <CardTitle className="text-xl text-foreground">
+              Gestão de Isolamentos
+            </CardTitle>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Monitoramento de pacientes com isolamentos ativos e identificação de riscos de contaminação cruzada.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-64 w-full" />
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="rounded-lg border border-border p-4 bg-muted/40">
+                <div className="flex items-center gap-3">
+                  <ShieldCheck className="h-6 w-6 text-primary" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Pacientes em isolamento</p>
+                    <p className="text-2xl font-semibold text-foreground">{totalPacientesIsolados}</p>
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-lg border border-border p-4 bg-muted/40">
+                <div className="flex items-center gap-3">
+                  <AlertTriangle className="h-6 w-6 text-destructive" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Pacientes com alerta</p>
+                    <p className="text-2xl font-semibold text-destructive">{totalPacientesEmRisco}</p>
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-lg border border-border p-4 bg-muted/40">
+                <div className="flex items-center gap-3">
+                  <Shield className="h-6 w-6 text-primary" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Pacientes em risco (%)</p>
+                    <p className="text-2xl font-semibold text-foreground">{percentualRisco}%</p>
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
-          <CardTitle className="text-xl text-foreground">
-            Dashboard de Isolamentos
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="text-center">
-          <div className="flex justify-center mb-4">
-            <Construction className="h-8 w-8 text-muted-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            Este dashboard está em desenvolvimento e será implementado em breve.
-          </p>
-          <p className="text-sm text-muted-foreground mt-2">
-            Conterá estatísticas de isolamentos ativos, tipos de isolamento, e alertas de precauções.
-          </p>
-        </CardContent>
-      </Card>
-    </div>
+
+            <div className="mt-6">
+              {pacientesIsolamento.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
+                  Nenhum paciente com isolamento ativo no momento.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Paciente</TableHead>
+                      <TableHead>Localização</TableHead>
+                      <TableHead>Isolamentos Ativos</TableHead>
+                      <TableHead>Alertas</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {pacientesIsolamento.map(paciente => {
+                      const risco = riscosPorPaciente.get(paciente.id);
+                      return (
+                        <TableRow key={paciente.id} className={risco ? 'bg-destructive/5' : undefined}>
+                          <TableCell className="font-medium text-foreground">
+                            {paciente.nome}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {formatarLocalizacao(paciente.setor, paciente.quarto, paciente.leito)}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-wrap gap-2">
+                              {paciente.isolamentos.map((iso, index) => (
+                                <Badge key={`${paciente.id}-iso-${index}`} variant="secondary">
+                                  {iso.siglaInfeccao || iso.sigla || iso.nomeInfeccao || 'Isolamento'}
+                                </Badge>
+                              ))}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            {risco ? (
+                              <div className="space-y-2">
+                                {risco.motivos.map(motivo => (
+                                  <div key={`${paciente.id}-${motivo}`} className="flex items-start gap-2 text-sm text-destructive">
+                                    <AlertTriangle className="mt-0.5 h-4 w-4" />
+                                    <span>{obterDescricaoRisco(motivo, risco.detalhes)}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <Badge variant="outline" className="text-muted-foreground">
+                                Sem alerta
+                              </Badge>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/hooks/useCollections.js
+++ b/src/hooks/useCollections.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { ROOMS_COLLECTION_PATH, PATIENTS_COLLECTION_PATH, BEDS_COLLECTION_PATH, SECTORS_COLLECTION_PATH, INFECTIONS_COLLECTION_PATH } from '@/lib/firebase-constants';
 
 const useCollection = (path) => {
   const [data, setData] = useState([]);
@@ -17,7 +18,8 @@ const useCollection = (path) => {
   return { data, loading };
 };
 
-export const usePacientes = () => useCollection('artifacts/regulafacil/public/data/pacientes');
-export const useLeitos = () => useCollection('artifacts/regulafacil/public/data/leitos');
-export const useSetores = () => useCollection('artifacts/regulafacil/public/data/setores');
-export const useInfeccoes = () => useCollection('artifacts/regulafacil/public/data/infeccoes');
+export const usePacientes = () => useCollection(PATIENTS_COLLECTION_PATH);
+export const useLeitos = () => useCollection(BEDS_COLLECTION_PATH);
+export const useSetores = () => useCollection(SECTORS_COLLECTION_PATH);
+export const useInfeccoes = () => useCollection(INFECTIONS_COLLECTION_PATH);
+export const useQuartos = () => useCollection(ROOMS_COLLECTION_PATH);

--- a/src/hooks/useDadosHospitalares.js
+++ b/src/hooks/useDadosHospitalares.js
@@ -1,6 +1,6 @@
 // src/hooks/useDadosHospitalares.js
 import { useMemo } from 'react';
-import { usePacientes, useLeitos, useSetores, useInfeccoes } from './useCollections';
+import { usePacientes, useLeitos, useSetores, useInfeccoes, useQuartos } from './useCollections';
 
 // Função interna para processar e enriquecer os dados
 const processarDados = (pacientes, leitos, setores, infeccoes) => {
@@ -215,8 +215,9 @@ export const useDadosHospitalares = () => {
   const { data: leitos, loading: loadingLeitos } = useLeitos();
   const { data: setores, loading: loadingSetores } = useSetores();
   const { data: infeccoes, loading: loadingInfeccoes } = useInfeccoes();
+  const { data: quartos, loading: loadingQuartos } = useQuartos();
 
-  const isLoading = loadingPacientes || loadingLeitos || loadingSetores || loadingInfeccoes;
+  const isLoading = loadingPacientes || loadingLeitos || loadingSetores || loadingInfeccoes || loadingQuartos;
 
   const dadosProcessados = useMemo(() => {
     if (isLoading) return { estrutura: {}, pacientesEnriquecidos: [], infeccoesMap: new Map() };
@@ -229,6 +230,7 @@ export const useDadosHospitalares = () => {
     leitos,
     setores,
     infeccoes,
+    quartos,
     loading: isLoading,
   };
 };

--- a/src/lib/compatibilidadeUtils.js
+++ b/src/lib/compatibilidadeUtils.js
@@ -117,3 +117,163 @@ export const encontrarLeitosCompativeis = (pacienteAlvo, hospitalData, modo = 'e
 };
 
 export { calcularIdade, getChavesIsolamentoAtivo };
+
+const normalizarTexto = (valor) => (valor || '').toString().trim().toUpperCase();
+
+const obterStatusIsolamentoAtivo = (isolamento) => {
+  if (!isolamento) return false;
+  if (typeof isolamento.statusConsideradoAtivo === 'boolean') {
+    return isolamento.statusConsideradoAtivo;
+  }
+  const status = (isolamento.status || '').toLowerCase();
+  return status === 'confirmado' || status === 'suspeito';
+};
+
+const extrairIdInfeccao = (isolamento) => {
+  if (!isolamento) return null;
+  const { infeccaoId } = isolamento;
+  if (typeof infeccaoId === 'object' && infeccaoId !== null) {
+    if (typeof infeccaoId.id !== 'undefined') {
+      return String(infeccaoId.id);
+    }
+    if (typeof infeccaoId.value !== 'undefined') {
+      return String(infeccaoId.value);
+    }
+  }
+  if (typeof infeccaoId !== 'undefined') {
+    return String(infeccaoId);
+  }
+  if (typeof isolamento.id !== 'undefined') {
+    return String(isolamento.id);
+  }
+  return null;
+};
+
+const obterIsolamentosAtivosIds = (paciente) => {
+  if (!paciente || !Array.isArray(paciente.isolamentos)) return [];
+  const ids = paciente.isolamentos
+    .filter(obterStatusIsolamentoAtivo)
+    .map(extrairIdInfeccao)
+    .filter(Boolean);
+  return Array.from(new Set(ids)).sort();
+};
+
+const motivosRisco = {
+  SETOR_ABERTO: 'setor_aberto',
+  AUSENCIA_COORTE: 'ausencia_coorte',
+  COORTE_INCOMPATIVEL: 'coorte_incompativel',
+};
+
+const registrarRisco = (mapa, pacienteId, motivo, contexto = {}) => {
+  if (!pacienteId) return;
+  const existente = mapa.get(pacienteId);
+  if (!existente) {
+    mapa.set(pacienteId, {
+      risco: true,
+      motivos: [motivo],
+      detalhes: contexto ? [contexto] : [],
+    });
+    return;
+  }
+
+  if (!existente.motivos.includes(motivo)) {
+    existente.motivos.push(motivo);
+  }
+  if (contexto && Object.keys(contexto).length) {
+    existente.detalhes.push(contexto);
+  }
+};
+
+export const identificarRiscosDeContaminacao = (
+  pacientes = [],
+  leitos = [],
+  quartos = [],
+  setores = [],
+) => {
+  const riscos = new Map();
+
+  if (!Array.isArray(pacientes) || !Array.isArray(leitos)) {
+    return riscos;
+  }
+
+  const leitosPorId = new Map(leitos.map(leito => [leito.id, leito]));
+  const setoresPorId = new Map(setores.map(setor => [setor.id, setor]));
+  const quartosPorId = new Map((Array.isArray(quartos) ? quartos : []).map(quarto => [quarto.id, quarto]));
+
+  const pacientesEnriquecidos = pacientes.map(paciente => {
+    const leito = leitosPorId.get(paciente.leitoId) || null;
+    const setor = leito ? setoresPorId.get(leito.setorId) : setoresPorId.get(paciente.setorId) || null;
+    const quarto = leito?.quartoId ? quartosPorId.get(leito.quartoId) || null : null;
+    const isolamentosIds = obterIsolamentosAtivosIds(paciente);
+
+    return {
+      id: paciente.id,
+      nome: paciente.nomePaciente || paciente.nome || '',
+      leito,
+      quarto,
+      setor,
+      setorTipo: normalizarTexto(setor?.tipoSetor),
+      setorNome: normalizarTexto(setor?.nomeSetor || setor?.nome || setor?.siglaSetor),
+      isolamentosIds,
+      possuiIsolamentoAtivo: isolamentosIds.length > 0,
+    };
+  });
+
+  // Risco por setor aberto (PS)
+  pacientesEnriquecidos.forEach(paciente => {
+    if (!paciente.possuiIsolamentoAtivo) return;
+    if (['PS DECISÃO CLINICA', 'PS DECISÃO CIRURGICA'].includes(paciente.setorNome)) {
+      registrarRisco(riscos, paciente.id, motivosRisco.SETOR_ABERTO, {
+        tipo: 'setor',
+        setorNome: paciente.setorNome,
+      });
+    }
+  });
+
+  // Agrupar por quarto para regras de enfermaria
+  const pacientesPorQuarto = new Map();
+  pacientesEnriquecidos.forEach(paciente => {
+    const quartoId = paciente.leito?.quartoId;
+    if (!quartoId) return;
+    if (!pacientesPorQuarto.has(quartoId)) {
+      pacientesPorQuarto.set(quartoId, []);
+    }
+    pacientesPorQuarto.get(quartoId).push(paciente);
+  });
+
+  pacientesPorQuarto.forEach((ocupantes, quartoId) => {
+    if (!ocupantes || ocupantes.length <= 1) return;
+
+    const setorTipo = ocupantes[0]?.setorTipo;
+    if (setorTipo !== 'ENFERMARIA') return;
+
+    const possuiSemIsolamento = ocupantes.some(ocupante => !ocupante.possuiIsolamentoAtivo);
+    const comIsolamento = ocupantes.filter(ocupante => ocupante.possuiIsolamentoAtivo);
+
+    if (!comIsolamento.length) return;
+
+    if (possuiSemIsolamento) {
+      comIsolamento.forEach(ocupante => {
+        registrarRisco(riscos, ocupante.id, motivosRisco.AUSENCIA_COORTE, {
+          tipo: 'ausencia_coorte',
+          quartoId,
+        });
+      });
+      return;
+    }
+
+    const chaveIsolamentos = comIsolamento.map(ocupante => ocupante.isolamentosIds.join('|'));
+    const todasIguais = chaveIsolamentos.every((chave, index, arr) => chave === arr[0]);
+
+    if (!todasIguais) {
+      ocupantes.forEach(ocupante => {
+        registrarRisco(riscos, ocupante.id, motivosRisco.COORTE_INCOMPATIVEL, {
+          tipo: 'coorte_incompativel',
+          quartoId,
+        });
+      });
+    }
+  });
+
+  return riscos;
+};


### PR DESCRIPTION
## Summary
- add contamination risk detection utility covering PS sectors, missing cohorting and incompatible isolations
- expose rooms data in the hospital data hook so dashboards can evaluate room context
- rebuild the isolation management dashboard to surface accurate risk alerts per patient

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54d7a23b08322815c5225dbc21753