### PR TITLE
Include cleaning status beds in vacancy report

### DIFF
--- a/src/components/modals/RelatorioLeitosVagosModal.jsx
+++ b/src/components/modals/RelatorioLeitosVagosModal.jsx
@@ -261,7 +261,7 @@ const RelatorioLeitosVagosModal = ({ isOpen, onClose }) => {
 
       const leitosVagos = [...quartosComLeitos.flatMap(quarto => quarto.leitos), ...leitosSemQuarto]
         .filter(leito =>
-          leito.status === 'Vago' &&
+          ['Vago', 'Higienização'].includes(leito.status) &&
           !leito.paciente &&
           !leito.reservaExterna &&
           !leito.regulacaoEmAndamento &&


### PR DESCRIPTION
## Summary
- include beds marked as Higienização in the vacant beds report modal so they appear alongside Vago beds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e560c31d6083228d6ca3e203902ea2