### PR TITLE
Add main indicators to regulation dashboard and improve bed modal

### DIFF
--- a/src/components/IndicadoresPrincipais.jsx
+++ b/src/components/IndicadoresPrincipais.jsx
@@ -1,0 +1,161 @@
+import React, { useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Users, Timer } from "lucide-react";
+import { useDadosHospitalares } from "@/hooks/useDadosHospitalares";
+
+const NOMES_SETORES_FOCO = [
+  "PS DECISÃO CLINICA",
+  "PS DECISÃO CIRURGICA",
+  "CC - RECUPERAÇÃO",
+];
+
+const parseDateValue = (value) => {
+  if (!value) return null;
+  if (typeof value.toDate === 'function') {
+    try {
+      return value.toDate();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const formatDuration = (milliseconds) => {
+  if (milliseconds == null || Number.isNaN(milliseconds)) {
+    return '—';
+  }
+
+  const totalMinutes = Math.max(0, Math.round(milliseconds / (60 * 1000)));
+  const minutesInDay = 60 * 24;
+  const days = Math.floor(totalMinutes / minutesInDay);
+  const remainingMinutes = totalMinutes % minutesInDay;
+  const hours = Math.floor(remainingMinutes / 60);
+  const minutes = remainingMinutes % 60;
+
+  const parts = [];
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0 || parts.length === 0) {
+    parts.push(`${minutes}m`);
+  }
+
+  return parts.join(' ');
+};
+
+const IndicadoresPrincipais = () => {
+  const { pacientes = [], setores = [], leitos = [] } = useDadosHospitalares();
+
+  const setoresAlvoIds = useMemo(() => {
+    const nomes = new Set(NOMES_SETORES_FOCO);
+    return new Set(
+      setores
+        .filter((setor) => nomes.has(setor?.nomeSetor))
+        .map((setor) => setor.id)
+        .filter(Boolean)
+    );
+  }, [setores]);
+
+  const leitosPorId = useMemo(() => {
+    return new Map(leitos.map((leito) => [leito.id, leito]));
+  }, [leitos]);
+
+  const aguardandoLeitoTotal = useMemo(() => {
+    if (!pacientes.length) {
+      return 0;
+    }
+
+    const ids = new Set();
+
+    pacientes.forEach((paciente) => {
+      if (!paciente) return;
+
+      const setorIdPaciente =
+        paciente.setorId || leitosPorId.get(paciente.leitoId)?.setorId || null;
+      const estaEmSetorAlvo = setorIdPaciente && setoresAlvoIds.has(setorIdPaciente);
+      const possuiPedidoUti = Boolean(paciente.pedidoUTI);
+
+      if ((estaEmSetorAlvo || possuiPedidoUti) && paciente.id) {
+        ids.add(paciente.id);
+      }
+    });
+
+    return ids.size;
+  }, [pacientes, leitosPorId, setoresAlvoIds]);
+
+  const { totalRegulacoes, tempoMedioMs } = useMemo(() => {
+    if (!pacientes.length) {
+      return { totalRegulacoes: 0, tempoMedioMs: null };
+    }
+
+    let somaDuracoes = 0;
+    let contagemValidos = 0;
+
+    const agora = new Date();
+
+    pacientes.forEach((paciente) => {
+      const regulacao = paciente?.regulacaoAtiva;
+      if (!regulacao) return;
+
+      const inicio = parseDateValue(regulacao.iniciadoEm);
+      if (!inicio) return;
+
+      const diff = agora.getTime() - inicio.getTime();
+      if (diff < 0) return;
+
+      somaDuracoes += diff;
+      contagemValidos += 1;
+    });
+
+    if (contagemValidos === 0) {
+      return { totalRegulacoes: 0, tempoMedioMs: null };
+    }
+
+    return {
+      totalRegulacoes: contagemValidos,
+      tempoMedioMs: somaDuracoes / contagemValidos,
+    };
+  }, [pacientes]);
+
+  const tempoMedioFormatado = tempoMedioMs != null ? formatDuration(tempoMedioMs) : '—';
+
+  const descricaoRegulacoes = totalRegulacoes === 0
+    ? 'Nenhuma regulação em andamento'
+    : `${totalRegulacoes} regulação${totalRegulacoes > 1 ? 'es' : ''} em andamento`;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <Card className="border-muted shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Pacientes Aguardando Leito</CardTitle>
+          <Users className="h-5 w-5 text-primary" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-3xl font-bold">{aguardandoLeitoTotal}</div>
+          <p className="text-xs text-muted-foreground">
+            Inclui setores PS Decisão e CC - Recuperação, além de pedidos ativos de UTI.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border-muted shadow-none">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Tempo Médio das Regulações</CardTitle>
+          <Timer className="h-5 w-5 text-primary" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-3xl font-bold">{tempoMedioFormatado}</div>
+          <p className="text-xs text-muted-foreground">{descricaoRegulacoes}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default IndicadoresPrincipais;

--- a/src/components/RegulacaoLeitosPage.jsx
+++ b/src/components/RegulacaoLeitosPage.jsx
@@ -21,6 +21,7 @@ import PanoramaDatePickerModal from './modals/PanoramaDatePickerModal';
 import PanoramaRegulacoesModal from './modals/PanoramaRegulacoesModal';
 import RegularPacienteModal from './modals/RegularPacienteModal';
 import PassagemPlantaoModal from './modals/PassagemPlantaoModal';
+import IndicadoresPrincipais from './IndicadoresPrincipais';
 
 const filtrosIniciais = {
   searchTerm: '',
@@ -65,9 +66,7 @@ const RegulacaoLeitosPage = () => {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-muted-foreground">
-              Métricas e KPIs serão exibidos aqui.
-            </p>
+            <IndicadoresPrincipais />
           </CardContent>
         </Card>
 

--- a/src/components/modals/MoverPacienteModal.jsx
+++ b/src/components/modals/MoverPacienteModal.jsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Search } from 'lucide-react';
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 const MoverPacienteModal = ({ isOpen, onClose, onMove, paciente, leito, dadosEstruturados }) => {
   const [busca, setBusca] = useState('');
@@ -113,62 +114,64 @@ const MoverPacienteModal = ({ isOpen, onClose, onMove, paciente, leito, dadosEst
           </div>
 
           {/* Lista de leitos disponíveis */}
-          <div className="flex-1 overflow-y-auto space-y-4">
-            {Object.entries(leitosPorSetor).map(([nomeSetor, leitosDoSetor]) => (
-              <div key={nomeSetor} className="space-y-2">
-                <h4 className="font-medium text-sm text-gray-700 sticky top-0 bg-background py-1">
-                  {nomeSetor} ({leitosDoSetor.length} disponível{leitosDoSetor.length !== 1 ? 'eis' : ''})
-                </h4>
-                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
-                  {leitosDoSetor.map(leitoItem => (
-                    <Card 
-                      key={leitoItem.id}
-                      className={`cursor-pointer transition-all ${
-                        leitoSelecionado?.id === leitoItem.id 
-                          ? 'ring-2 ring-primary bg-primary/5' 
-                          : 'hover:shadow-md'
-                      }`}
-                      onClick={() => setLeitoSelecionado(leitoItem)}
-                    >
-                      <CardContent className="p-3">
-                        <div className="space-y-2">
-                          <div className="flex items-center justify-between">
-                            <span className="font-medium text-sm">{leitoItem.codigoLeito}</span>
-                            <Badge 
-                              variant="outline" 
-                              className={
-                                leitoItem.status === 'Vago' 
-                                  ? 'bg-green-100 text-green-800' 
-                                  : 'bg-yellow-100 text-yellow-800'
-                              }
-                            >
-                              {leitoItem.status}
-                            </Badge>
+          <ScrollArea className="h-[450px] pr-2">
+            <div className="space-y-4">
+              {Object.entries(leitosPorSetor).map(([nomeSetor, leitosDoSetor]) => (
+                <div key={nomeSetor} className="space-y-2">
+                  <h4 className="font-medium text-sm text-gray-700 sticky top-0 bg-background py-1">
+                    {nomeSetor} ({leitosDoSetor.length} disponível{leitosDoSetor.length !== 1 ? 'eis' : ''})
+                  </h4>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+                    {leitosDoSetor.map(leitoItem => (
+                      <Card
+                        key={leitoItem.id}
+                        className={`cursor-pointer transition-all ${
+                          leitoSelecionado?.id === leitoItem.id
+                            ? 'ring-2 ring-primary bg-primary/5'
+                            : 'hover:shadow-md'
+                        }`}
+                        onClick={() => setLeitoSelecionado(leitoItem)}
+                      >
+                        <CardContent className="p-3">
+                          <div className="space-y-2">
+                            <div className="flex items-center justify-between">
+                              <span className="font-medium text-sm">{leitoItem.codigoLeito}</span>
+                              <Badge
+                                variant="outline"
+                                className={
+                                  leitoItem.status === 'Vago'
+                                    ? 'bg-green-100 text-green-800'
+                                    : 'bg-yellow-100 text-yellow-800'
+                                }
+                              >
+                                {leitoItem.status}
+                              </Badge>
+                            </div>
+                            {leitoItem.nomeQuarto && (
+                              <p className="text-xs text-muted-foreground">
+                                Quarto: {leitoItem.nomeQuarto}
+                              </p>
+                            )}
+                            {leitoItem.isPCP && (
+                              <Badge variant="secondary" className="text-xs">
+                                PCP
+                              </Badge>
+                            )}
                           </div>
-                          {leitoItem.nomeQuarto && (
-                            <p className="text-xs text-muted-foreground">
-                              Quarto: {leitoItem.nomeQuarto}
-                            </p>
-                          )}
-                          {leitoItem.isPCP && (
-                            <Badge variant="secondary" className="text-xs">
-                              PCP
-                            </Badge>
-                          )}
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
 
-          {leitosFiltrados.length === 0 && (
-            <div className="text-center py-8 text-muted-foreground">
-              {busca ? 'Nenhum leito encontrado para a busca.' : 'Nenhum leito disponível no momento.'}
+              {leitosFiltrados.length === 0 && (
+                <div className="text-center py-8 text-muted-foreground">
+                  {busca ? 'Nenhum leito encontrado para a busca.' : 'Nenhum leito disponível no momento.'}
+                </div>
+              )}
             </div>
-          )}
+          </ScrollArea>
         </div>
 
         <DialogFooter>


### PR DESCRIPTION
## Summary
- wrap the bed selection list in MoverPacienteModal with a ScrollArea to allow vertical scrolling
- add an IndicadoresPrincipais component that calculates and displays key regulation metrics
- embed the new indicators component in the RegulacaoLeitosPage dashboard header

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5632f27c083228bf5e51a3b7526db